### PR TITLE
Fix assignment to lnAddr when starting (TCP) listeners

### DIFF
--- a/layer4/app.go
+++ b/layer4/app.go
@@ -78,6 +78,7 @@ func (a *App) Start() error {
 						return err
 					}
 					a.listeners = append(a.listeners, ln)
+					lnAddr = ln.Addr().Network() + "/" + ln.Addr().String()
 					go s.serve(ln)
 				}
 				s.logger.Debug("listening "+addr.Network,


### PR DESCRIPTION
Previously, when starting a TCP listener and having logging
set to debug level, the address to listen on would show up like this:

`DEBUG	layer4	listening tcp	{"address": ""}`

With this change, it shows up like this:

`DEBUG	layer4	listening tcp	{"address": "tcp/127.0.0.1:8443"}`

I'm not sure if this is the format that is wanted, but it's at least more informative 😉 

Maybe I should replace the `127.0.0.1` with `localhost`, as is done for the admin endpoint:

`INFO	admin	admin endpoint started	{"address": "tcp/localhost:2019", "enforce_origin": false, "origins": ["[::1]:2019", "127.0.0.1:2019", "localhost:2019"]}`

That would require taking info from the configuration instead of from the `ln` struct, though, if I'm correct.