### PR TITLE
add downstream PROXY protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,3 +228,59 @@ Same as previous, but filter by HTTP Host header and/or TLS ClientHello ServerNa
 	}
 }
 ```
+
+Unwrap PROXY protocol, and forward the traffic to upstream if PROXY protocol matched, else forward the traffic to another http backend.
+
+```json
+{
+    "apps": {
+        "layer4": {
+            "servers": {
+                "example": {
+                    "listen": ["0.0.0.0:5000"],
+                    "routes": [
+                        {
+                            "match": [
+                                {
+                                    "proxyprotocol": {
+                                        "allowed_ranges": [
+                                            "127.0.0.0/8",
+                                            "10.144.0.0/16"
+                                        ]
+                                    }
+                                }
+                            ],
+                            "handle": [
+                                {
+                                    "handler": "proxyprotocol"
+                                },
+                                {
+                                    "handler": "proxy",
+                                    "upstreams": [
+                                        { "dial": ["localhost:8080"] }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "match": [
+                                {
+                                    "http": []
+                                }
+                            ],
+                            "handle": [
+                                {
+                                    "handler": "proxy",
+                                    "upstreams": [
+                                        { "dial": ["localhost:8000"] }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/caddyserver/caddy/v2 v2.3.0-rc.1
+	github.com/mastercactapus/proxyprotocol v0.0.3 // indirect
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ github.com/marten-seemann/qtls v0.10.0 h1:ECsuYUKalRL240rRD4Ri33ISb7kAQ3qGDlrrl5
 github.com/marten-seemann/qtls v0.10.0/go.mod h1:UvMd1oaYDACI99/oZUYLzMCkBXQVT0aGm99sJhbT8hs=
 github.com/marten-seemann/qtls-go1-15 v0.1.1 h1:LIH6K34bPVttyXnUWixk0bzH6/N07VxbSabxn5A5gZQ=
 github.com/marten-seemann/qtls-go1-15 v0.1.1/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
+github.com/mastercactapus/proxyprotocol v0.0.3 h1:WpDMFKCYdF8NsoA6OrXyNKyZrzMURqqOP1PE7297RCE=
+github.com/mastercactapus/proxyprotocol v0.0.3/go.mod h1:X8FRVEDZz9FkrIoL4QYTBF4Ka4ELwTv0sah0/5NxCPw=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=

--- a/imports.go
+++ b/imports.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/mholt/caddy-l4/modules/l4echo"
 	_ "github.com/mholt/caddy-l4/modules/l4http"
 	_ "github.com/mholt/caddy-l4/modules/l4proxy"
+	_ "github.com/mholt/caddy-l4/modules/l4proxyprotocol"
 	_ "github.com/mholt/caddy-l4/modules/l4ssh"
 	_ "github.com/mholt/caddy-l4/modules/l4tee"
 	_ "github.com/mholt/caddy-l4/modules/l4throttle"

--- a/layer4/utils.go
+++ b/layer4/utils.go
@@ -1,0 +1,57 @@
+package layer4
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func GetCIDRFromString(str string) (ipNet *net.IPNet, err error) {
+	if strings.Contains(str, "/") {
+		_, ipNet, err = net.ParseCIDR(str)
+		if err != nil {
+			return nil, fmt.Errorf("parsing CIDR expression: %v", err)
+		}
+	} else {
+		ip := net.ParseIP(str)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid IP address: %s", str)
+		}
+		mask := len(ip) * 8
+		ipNet = &net.IPNet{
+			IP:   ip,
+			Mask: net.CIDRMask(mask, mask),
+		}
+	}
+	return
+}
+
+func GetCIDRsFromStrings(ss []string) (ipNets []*net.IPNet, err error) {
+	ipNets = make([]*net.IPNet, len(ss))
+	var ipNet *net.IPNet
+	for i, str := range ss {
+		ipNet, err = GetCIDRFromString(str)
+		if err != nil {
+			return
+		}
+		ipNets[i] = ipNet
+	}
+	return
+}
+
+
+func GetClientIP(cx *Connection) (net.IP, error) {
+	remote := cx.Conn.RemoteAddr().String()
+
+	ipStr, _, err := net.SplitHostPort(remote)
+	if err != nil {
+		ipStr = remote // OK; probably didn't have a port
+	}
+
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return nil, fmt.Errorf("invalid client IP address: %s", ipStr)
+	}
+
+	return ip, nil
+}

--- a/modules/l4proxyprotocol/handler.go
+++ b/modules/l4proxyprotocol/handler.go
@@ -1,0 +1,62 @@
+// Copyright 2021 contrun
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxyprotocol
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mastercactapus/proxyprotocol"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
+)
+
+func init() {
+	caddy.RegisterModule(Handler{})
+}
+
+// Handler is a connection handler that terminates PROXY protocol.
+type Handler struct {
+	logger *zap.Logger
+}
+
+// CaddyModule returns the Caddy module information.
+func (Handler) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.handlers.proxyprotocol",
+		New: func() caddy.Module { return new(Handler) },
+	}
+}
+
+// Provision sets up the module.
+func (t *Handler) Provision(ctx caddy.Context) error {
+	t.logger = ctx.Logger(t)
+	return nil
+}
+
+// Handle handles the connections.
+func (t *Handler) Handle(cx *layer4.Connection, next layer4.Handler) error {
+	conn := cx.GetVar("terminated_proxy_connection")
+	if conn == nil {
+		t.logger.Warn("terminated_proxy_connection not found, did you match PROXY protocol before handle it?")
+		return next.Handle(cx)
+	}
+	t.logger.Debug("terminated PROXY protocol")
+	return next.Handle(cx.Wrap(conn.(*proxyprotocol.Conn)))
+}
+
+// Interface guards
+var (
+	_ caddy.Provisioner  = (*Handler)(nil)
+	_ layer4.NextHandler = (*Handler)(nil)
+)

--- a/modules/l4proxyprotocol/matcher.go
+++ b/modules/l4proxyprotocol/matcher.go
@@ -1,0 +1,105 @@
+// Copyright 2021 contrun
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxyprotocol
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mastercactapus/proxyprotocol"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
+)
+
+func init() {
+	caddy.RegisterModule(MatchPROXYProtocol{})
+}
+
+// MatchPROXYProtocol is able to match PROXY protocol connections.
+type MatchPROXYProtocol struct {
+	// Note by default, we allow all client ips.
+	AllowedRanges []string `json:"allowed_ranges,omitempty"`
+
+	allowedSubnets []*net.IPNet
+	logger         *zap.Logger
+}
+
+// CaddyModule returns the Caddy module information.
+func (MatchPROXYProtocol) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.matchers.proxyprotocol",
+		New: func() caddy.Module { return new(MatchPROXYProtocol) },
+	}
+}
+
+func (m MatchPROXYProtocol) isIPAllowed(ip net.IP) bool {
+	if len(m.allowedSubnets) == 0 {
+		return true
+	}
+	for _, n := range m.allowedSubnets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Provision sets up the module.
+func (t *MatchPROXYProtocol) Provision(ctx caddy.Context) error {
+	t.logger = ctx.Logger(t)
+	cidrs, err := layer4.GetCIDRsFromStrings(t.AllowedRanges)
+	if err != nil {
+		return err
+	}
+	t.allowedSubnets = cidrs
+	return nil
+}
+
+// Match returns true if the connection is a PROXY protocol handshake.
+// Then saves the terminated proxy protocol to `terminated_proxy_connection`.
+func (m MatchPROXYProtocol) Match(cx *layer4.Connection) (bool, error) {
+	// We use `cx.Conn` instead of `cx` here as proxyprotocol already only peeks into the packet.
+	conn := proxyprotocol.NewConn(cx, time.Time{})
+	// TODO: Figure out if this call will block when there is not enough data.
+	_, err := conn.ProxyHeader()
+	if err != nil {
+		m.logger.Debug("matching PROXY protocol", zap.Error(err))
+		var headerErr *proxyprotocol.InvalidHeaderErr
+		if errors.As(err, &headerErr) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	clientIP, err := layer4.GetClientIP(cx)
+	if err != nil {
+		return false, err
+	}
+	if m.isIPAllowed(clientIP) {
+		m.logger.Debug("matched PROXY protocol", zap.String("clientIP", clientIP.String()))
+		cx.SetVar("terminated_proxy_connection", conn)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Interface guards
+var (
+	_ layer4.ConnMatcher = (*MatchPROXYProtocol)(nil)
+	_ caddy.Provisioner  = (*MatchPROXYProtocol)(nil)
+)


### PR DESCRIPTION
This PR add downstream PROXY protocol support. Reading from the source of `github.com/mastercactapus/proxyprotocol`, it seems to me that the matcher will not blockingly wait even if there is not enough data. But I need to verify that and find a way to reuse `github.com/mastercactapus/proxyprotocol`.