### PR TITLE
l4proxy: add proxy_protocol matcher

### DIFF
--- a/modules/l4proxy/matcher.go
+++ b/modules/l4proxy/matcher.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxy
+
+import (
+	"bufio"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mastercactapus/proxyprotocol"
+	"github.com/mholt/caddy-l4/layer4"
+)
+
+func init() {
+	caddy.RegisterModule(MatchPROXY{})
+}
+
+type MatchPROXY struct{}
+
+// CaddyModule returns the Caddy module information.
+func (MatchPROXY) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.matchers.PROXY",
+		New: func() caddy.Module { return new(MatchPROXY) },
+	}
+}
+
+// Match returns true if the connection looks like SSH.
+func (m MatchPROXY) Match(cx *layer4.Connection) (bool, error) {
+	_, err := proxyprotocol.Parse(bufio.NewReader(cx))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Interface guard
+var _ layer4.ConnMatcher = (*MatchPROXY)(nil)

--- a/modules/l4proxy/matcher.go
+++ b/modules/l4proxy/matcher.go
@@ -31,21 +31,21 @@ var (
 )
 
 func init() {
-	caddy.RegisterModule(MatchPROXY{})
+	caddy.RegisterModule(MatchProxyProtocol{})
 }
 
-type MatchPROXY struct{}
+type MatchProxyProtocol struct{}
 
 // CaddyModule returns the Caddy module information.
-func (MatchPROXY) CaddyModule() caddy.ModuleInfo {
+func (MatchProxyProtocol) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
-		ID:  "layer4.matchers.ProxyProtocol",
-		New: func() caddy.Module { return new(MatchPROXY) },
+		ID:  "layer4.matchers.proxy_protocol",
+		New: func() caddy.Module { return new(MatchProxyProtocol) },
 	}
 }
 
 // Match returns true if the connection looks like it is using the Proxy Protocol.
-func (m MatchPROXY) Match(cx *layer4.Connection) (bool, error) {
+func (m MatchProxyProtocol) Match(cx *layer4.Connection) (bool, error) {
 	p := make([]byte, 4)
 	_, err := io.ReadFull(cx, p)
 	if err != nil {
@@ -87,4 +87,4 @@ func (m MatchPROXY) Match(cx *layer4.Connection) (bool, error) {
 }
 
 // Interface guard
-var _ layer4.ConnMatcher = (*MatchPROXY)(nil)
+var _ layer4.ConnMatcher = (*MatchProxyProtocol)(nil)

--- a/modules/l4proxy/matcher.go
+++ b/modules/l4proxy/matcher.go
@@ -15,7 +15,9 @@
 package l4proxy
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"io"
 
 	"github.com/caddyserver/caddy/v2"
@@ -24,7 +26,7 @@ import (
 
 // https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 var (
-	headerV1Prefix = []byte("PROXY")
+	headerV1Prefix = []byte("PROX") // intentional to not include "Y", see match() function for details
 	headerV2Prefix = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
 )
 
@@ -44,7 +46,7 @@ func (MatchPROXY) CaddyModule() caddy.ModuleInfo {
 
 // Match returns true if the connection looks like it is using the Proxy Protocol.
 func (m MatchPROXY) Match(cx *layer4.Connection) (bool, error) {
-	p := make([]byte, 5)
+	p := make([]byte, 4)
 	_, err := io.ReadFull(cx, p)
 	if err != nil {
 		return false, err
@@ -54,14 +56,28 @@ func (m MatchPROXY) Match(cx *layer4.Connection) (bool, error) {
 	}
 
 	buf := p[:]
-	// read 7 more bytes and append to buf
-	// to match against v2 header which starts with a 12 byte block
-	p = make([]byte, 7)
-	_, err = io.ReadFull(cx, p)
-	if err != nil {
-		return false, err
+	bufReader := bufio.NewReader(cx)
+	for i := 1; i <= 8; i++ {
+		// read the next 8 bytes, one byte at a time
+		// since 5th byte being null is valid in v2 header
+		// but is considered EOF by readers
+		b, err := bufReader.ReadByte()
+		if err == nil {
+			buf = append(buf, b)
+			continue
+		}
+
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			return false, err
+		}
+
+		// 4 bytes were already read, so i == 1 is the 5th byte
+		if i != 1 {
+			return false, err
+		}
+
+		buf = append(buf, 0x00)
 	}
-	buf = append(buf, p...)
 
 	if bytes.Equal(buf, headerV2Prefix) {
 		return true, nil


### PR DESCRIPTION
adds capability for part of #20 

- not sure yet on how to build caddy locally that includes changes to a module. This instruction in [README](https://github.com/mholt/caddy-l4#compiling) doesn't work me, I don't see the layer4 modules, if I build that way
> In the project folder, run xcaddy just like you would run caddy. For example: xcaddy list-modules --versions (you should see the layer4 modules).

-  Not familiar with how could we test this module which operates at layer4? Do we use certain tools to simulate traffic? Although this matcher is very simple, would like to test that it works, to be sure.