### PR TITLE
l4xmpp: Add support for matching XMPP connections, match TLS-ALPN

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -21,8 +21,8 @@ import (
 	_ "github.com/mholt/caddy-l4/modules/l4http"
 	_ "github.com/mholt/caddy-l4/modules/l4proxy"
 	_ "github.com/mholt/caddy-l4/modules/l4ssh"
-	_ "github.com/mholt/caddy-l4/modules/l4xmpp"
 	_ "github.com/mholt/caddy-l4/modules/l4tee"
 	_ "github.com/mholt/caddy-l4/modules/l4throttle"
 	_ "github.com/mholt/caddy-l4/modules/l4tls"
+	_ "github.com/mholt/caddy-l4/modules/l4xmpp"
 )

--- a/imports.go
+++ b/imports.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/mholt/caddy-l4/modules/l4http"
 	_ "github.com/mholt/caddy-l4/modules/l4proxy"
 	_ "github.com/mholt/caddy-l4/modules/l4ssh"
+	_ "github.com/mholt/caddy-l4/modules/l4xmpp"
 	_ "github.com/mholt/caddy-l4/modules/l4tee"
 	_ "github.com/mholt/caddy-l4/modules/l4throttle"
 	_ "github.com/mholt/caddy-l4/modules/l4tls"

--- a/modules/l4tls/alpn_matcher.go
+++ b/modules/l4tls/alpn_matcher.go
@@ -1,0 +1,56 @@
+// Copyright
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4tls
+
+import (
+  "crypto/tls"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
+)
+
+func init() {
+	caddy.RegisterModule(MatchALPN{})
+}
+
+type MatchALPN []string
+
+// CaddyModule returns the Caddy module information.
+func (MatchALPN) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "tls.handshake_match.alpn",
+		New: func() caddy.Module { return new(MatchALPN) },
+	}
+}
+
+func (m MatchALPN) Match(hello *tls.ClientHelloInfo) bool {
+  clientProtocols := hello.SupportedProtos
+  if len(clientProtocols) == 0 {
+    return false
+  }
+	for _, alpn := range m {
+		for _, clientProtocol := range clientProtocols {
+      if alpn == string(clientProtocol) {
+        return true
+      }
+    }
+	}
+	return false
+}
+
+// Interface guards
+var (
+  _ caddytls.ConnectionMatcher = (*MatchALPN)(nil)
+)

--- a/modules/l4tls/alpn_matcher.go
+++ b/modules/l4tls/alpn_matcher.go
@@ -1,4 +1,4 @@
-// Copyright
+// Copyright 2020 Matthew Holt
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 package l4tls
 
 import (
-  "crypto/tls"
+	"crypto/tls"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
@@ -36,21 +36,18 @@ func (MatchALPN) CaddyModule() caddy.ModuleInfo {
 }
 
 func (m MatchALPN) Match(hello *tls.ClientHelloInfo) bool {
-  clientProtocols := hello.SupportedProtos
-  if len(clientProtocols) == 0 {
-    return false
-  }
+	clientProtocols := hello.SupportedProtos
 	for _, alpn := range m {
 		for _, clientProtocol := range clientProtocols {
-      if alpn == string(clientProtocol) {
-        return true
-      }
-    }
+			if alpn == string(clientProtocol) {
+				return true
+			}
+		}
 	}
 	return false
 }
 
 // Interface guards
 var (
-  _ caddytls.ConnectionMatcher = (*MatchALPN)(nil)
+	_ caddytls.ConnectionMatcher = (*MatchALPN)(nil)
 )

--- a/modules/l4xmpp/matcher.go
+++ b/modules/l4xmpp/matcher.go
@@ -41,7 +41,7 @@ func (MatchXMPP) CaddyModule() caddy.ModuleInfo {
 func (m MatchXMPP) Match(cx *layer4.Connection) (bool, error) {
 	p := make([]byte, minXmppLength)
 	n, err := io.ReadFull(cx, p)
-	if err != nil || n < minXmppLength {	// needs at least 50 (fix for adium/pidgin)
+	if err != nil || n < minXmppLength { // needs at least 50 (fix for adium/pidgin)
 		return false, nil
 	}
 	return strings.Contains(string(p), xmppWord), nil

--- a/modules/l4xmpp/matcher.go
+++ b/modules/l4xmpp/matcher.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4xmpp
+
+import (
+	"io"
+	"strings"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mholt/caddy-l4/layer4"
+)
+
+func init() {
+	caddy.RegisterModule(MatchXMPP{})
+}
+
+// MatchXMPP is able to match XMPP connections.
+type MatchXMPP struct{}
+
+// CaddyModule returns the Caddy module information.
+func (MatchXMPP) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.matchers.xmpp",
+		New: func() caddy.Module { return new(MatchXMPP) },
+	}
+}
+
+// Match returns true if the connection looks like XMPP.
+func (m MatchXMPP) Match(cx *layer4.Connection) (bool, error) {
+	p := make([]byte, minXmppLength)
+	n, err := io.ReadFull(cx, p)
+	if err != nil || n < minXmppLength {	// needs at least 50 (fix for adium/pidgin)
+		return false, nil
+	}
+	return strings.Contains(string(p), xmppWord), nil
+}
+
+var xmppWord = "jabber"
+var minXmppLength = 50
+
+// Interface guard
+var _ layer4.ConnMatcher = (*MatchXMPP)(nil)


### PR DESCRIPTION
1. Add generic ALPN matcher, which is used to match `xmpp-client` for XMPP. Let me know if this is better suited elsewhere (like the main Caddy repository).
2. Add XMPP matcher, which is similar to SSH matcher except it looks for the word `jabber` in the [first 50 bytes](https://github.com/yrutschle/sslh/blob/0e118a109c0407e47c8e43e37662df0f6c0367f2/probe.c#L175). 

Use case: Replacement for forwarding Snikket traffic over port 443 to relevant service; documented [here](https://github.com/snikket-im/snikket-server/blob/master/docs/advanced/reverse_proxy.md#sslh) using `sslh`