### PR TITLE
Reformat README json to use 2 space indents

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,22 @@ A simple echo server:
 
 ```json
 {
-	"apps": {
-		"layer4": {
-			"servers": {
-				"example": {
-					"listen": ["127.0.0.1:5000"],
-					"routes": [
-						{
-							"handle": [
-								{"handler": "echo"}
-							]
-						}
-					]
-				}
-			}
-		}
-	}
+  "apps": {
+    "layer4": {
+      "servers": {
+        "example": {
+          "listen": ["127.0.0.1:5000"],
+          "routes": [
+            {
+              "handle": [
+                {"handler": "echo"}
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -96,35 +96,35 @@ A simple echo server with TLS termination that uses a self-signed cert for `loca
 
 ```json
 {
-	"apps": {
-		"layer4": {
-			"servers": {
-				"example": {
-					"listen": ["127.0.0.1:5000"],
-					"routes": [
-						{
-							"handle": [
-								{"handler": "tls"},
-								{"handler": "echo"}
-							]
-						}
-					]
-				}
-			}
-		},
-		"tls": {
-			"certificates": {
-				"automate": ["localhost"]
-			},
-			"automation": {
-				"policies": [
-					{
-						"issuer": {"module": "internal"}
-					}
-				]
-			}
-		}
-	}
+  "apps": {
+    "layer4": {
+      "servers": {
+        "example": {
+          "listen": ["127.0.0.1:5000"],
+          "routes": [
+            {
+              "handle": [
+                {"handler": "tls"},
+                {"handler": "echo"}
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "tls": {
+      "certificates": {
+        "automate": ["localhost"]
+      },
+      "automation": {
+        "policies": [
+          {
+            "issuer": {"module": "internal"}
+          }
+        ]
+      }
+    }
+  }
 }
 ```
 
@@ -132,50 +132,50 @@ A simple TCP reverse proxy that terminates TLS on 993, and sends the PROXY proto
 
 ```json
 {
-	"apps": {
-		"layer4": {
-			"servers": {
-				"secure-imap": {
-					"listen": ["0.0.0.0:993"],
-					"routes": [
-						{
-							"handle": [
-								{
-									"handler": "tls"
-								},
-								{
-									"handler": "proxy",
-									"proxy_protocol": "v1",
-									"upstreams": [
-										{"dial": ["localhost:143"]}
-									]
-								}
-							]
-						}
-					]
-				},
-				"normal-imap": {
-					"listen": ["0.0.0.0:143"],
-					"routes": [
-						{
-							"handle": [
-								{
-									"handler": "proxy_protocol"
-								},
-								{
-									"handler": "proxy",
-									"proxy_protocol": "v2",
-									"upstreams": [
-										{"dial": ["localhost:1143"]}
-									]
-								}
-							]
-						}
-					]
-				}
-			}
-		}
-	}
+  "apps": {
+    "layer4": {
+      "servers": {
+        "secure-imap": {
+          "listen": ["0.0.0.0:993"],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "handler": "tls"
+                },
+                {
+                  "handler": "proxy",
+                  "proxy_protocol": "v1",
+                  "upstreams": [
+                    {"dial": ["localhost:143"]}
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "normal-imap": {
+          "listen": ["0.0.0.0:143"],
+          "routes": [
+            {
+              "handle": [
+                {
+                  "handler": "proxy_protocol"
+                },
+                {
+                  "handler": "proxy",
+                  "proxy_protocol": "v2",
+                  "upstreams": [
+                    {"dial": ["localhost:1143"]}
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -183,47 +183,47 @@ A multiplexer that proxies HTTP to one backend, and TLS to another (without term
 
 ```json
 {
-	"apps": {
-		"layer4": {
-			"servers": {
-				"example": {
-					"listen": ["127.0.0.1:5000"],
-					"routes": [
-						{
-							"match": [
-								{
-									"http": []
-								}
-							],
-							"handle": [
-								{
-									"handler": "proxy",
-									"upstreams": [
-										{"dial": ["localhost:80"]}
-									]
-								}
-							]
-						},
-						{
-							"match": [
-								{
-									"tls": {}
-								}
-							],
-							"handle": [
-								{
-									"handler": "proxy",
-									"upstreams": [
-										{"dial": ["localhost:443"]}
-									]
-								}
-							]
-						}
-					]
-				}
-			}
-		}
-	}
+  "apps": {
+    "layer4": {
+      "servers": {
+        "example": {
+          "listen": ["127.0.0.1:5000"],
+          "routes": [
+            {
+              "match": [
+                {
+                  "http": []
+                }
+              ],
+              "handle": [
+                {
+                  "handler": "proxy",
+                  "upstreams": [
+                    {"dial": ["localhost:80"]}
+                  ]
+                }
+              ]
+            },
+            {
+              "match": [
+                {
+                  "tls": {}
+                }
+              ],
+              "handle": [
+                {
+                  "handler": "proxy",
+                  "upstreams": [
+                    {"dial": ["localhost:443"]}
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -233,50 +233,50 @@ Same as previous, but filter by HTTP Host header and/or TLS ClientHello ServerNa
 
 ```json
 {
-	"apps": {
-		"layer4": {
-			"servers": {
-				"example": {
-					"listen": ["127.0.0.1:5000"],
-					"routes": [
-						{
-							"match": [
-								{
-									"http": [
-										{"host": ["example.com"]}
-									]
-								}
-							],
-							"handle": [
-								{
-									"handler": "proxy",
-									"upstreams": [
-										{"dial": ["localhost:80"]}
-									]
-								}
-							]
-						},
-						{
-							"match": [
-								{
-									"tls": {
-										"sni": ["example.net"]
-									}
-								}
-							],
-							"handle": [
-								{
-									"handler": "proxy",
-									"upstreams": [
-										{"dial": ["localhost:443"]}
-									]
-								}
-							]
-						}
-					]
-				}
-			}
-		}
-	}
+  "apps": {
+    "layer4": {
+      "servers": {
+        "example": {
+          "listen": ["127.0.0.1:5000"],
+          "routes": [
+            {
+              "match": [
+                {
+                  "http": [
+                    {"host": ["example.com"]}
+                  ]
+                }
+              ],
+              "handle": [
+                {
+                  "handler": "proxy",
+                  "upstreams": [
+                    {"dial": ["localhost:80"]}
+                  ]
+                }
+              ]
+            },
+            {
+              "match": [
+                {
+                  "tls": {
+                    "sni": ["example.net"]
+                  }
+                }
+              ],
+              "handle": [
+                {
+                  "handler": "proxy",
+                  "upstreams": [
+                    {"dial": ["localhost:443"]}
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
 }
 ```


### PR DESCRIPTION
Json in README code blocks is displayed in browser with 8-wide tabs which makes it hard to read.

This PR reformats them to use 2 space indents instead.