### PR TITLE
server: Don't close underlying UDP conn after handling

### DIFF
--- a/layer4/server.go
+++ b/layer4/server.go
@@ -131,6 +131,11 @@ func (pc packetConn) Write(b []byte) (n int, err error) {
 	return pc.PacketConn.WriteTo(b, pc.addr)
 }
 
+func (pc packetConn) Close() error {
+	// Do nothing, we don't want to close the UDP server
+	return nil
+}
+
 func (pc packetConn) RemoteAddr() net.Addr { return pc.addr }
 
 var udpBufPool = sync.Pool{


### PR DESCRIPTION
Should fix #53, and a bunch of other issues saying that UDP wasn't working properly, that were closed without the problem being totally understood