### PR TITLE
fix: make http2 matcher compatible with firefox

### DIFF
--- a/modules/l4http/httpmatcher.go
+++ b/modules/l4http/httpmatcher.go
@@ -135,9 +135,9 @@ func (m MatchHTTP) handleHttp2WithPriorKnowledge(reader io.Reader, req *http.Req
 
 	framer := http2.NewFramer(io.Discard, reader)
 
-	// read the first 3 frames until we get a headers frame (skipping settings & window update frames)
+	// read the first 10 frames until we get a headers frame (skipping settings, window update & priority frames)
 	var frame http2.Frame
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 10; i++ {
 		frame, err = framer.ReadFrame()
 		if err != nil {
 			return err
@@ -148,7 +148,7 @@ func (m MatchHTTP) handleHttp2WithPriorKnowledge(reader io.Reader, req *http.Req
 	}
 
 	if frame.Header().Type != http2.FrameHeaders {
-		return fmt.Errorf("failed to read a http2 headers frame after 3 attemps")
+		return fmt.Errorf("failed to read a http2 headers frame after 10 attempts")
 	}
 
 	decoder := hpack.NewDecoder(4096, nil) // max table size 4096 from http2.initialHeaderTableSize


### PR DESCRIPTION
Firefox sends multiple (currently 6) priority frames before the headers frame is send, which means we have to increase the number of attempts to find the headers frame.

Apparently they are used as "virtual streams" see:
https://stackoverflow.com/a/36938232

Here is a screenshot of firefox starting a http2 connection:
![http2-firefox](https://user-images.githubusercontent.com/17772145/176962132-412fb538-170b-49e3-9427-e1af951eeded.png)

In this case it worked because the connection was proxied via cloudflare. But without this fix and cloudflare the connection matching fails with the "failed to read a http2 headers frame after 3 attempts" error.