### PR TITLE
Fixes and Logging

### DIFF
--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -83,7 +83,10 @@ func (cx *Connection) Read(p []byte) (n int, err error) {
 			cx.bufReader = nil
 			err = nil
 		}
-		return
+		// prevent first read from returning 0 bytes because of empty bufReader
+		if !(n == 0 && err == nil) {
+			return
+		}
 	}
 
 	// buffer has been "depleted" so read from

--- a/layer4/connection_test.go
+++ b/layer4/connection_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"net"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestConnection_RecordAndRewind(t *testing.T) {
@@ -11,7 +13,7 @@ func TestConnection_RecordAndRewind(t *testing.T) {
 	defer in.Close()
 	defer out.Close()
 
-	cx := WrapConnection(out, &bytes.Buffer{})
+	cx := WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
 	defer cx.Close()
 
 	matcherData := []byte("foo")

--- a/layer4/connection_test.go
+++ b/layer4/connection_test.go
@@ -1,0 +1,86 @@
+package layer4
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func TestConnection_RecordAndRewind(t *testing.T) {
+	in, out := net.Pipe()
+	defer in.Close()
+	defer out.Close()
+
+	cx := WrapConnection(out, &bytes.Buffer{})
+	defer cx.Close()
+
+	matcherData := []byte("foo")
+	consumeData := []byte("bar")
+
+	buf := make([]byte, len(matcherData))
+
+	go func() {
+		in.Write(matcherData)
+		in.Write(consumeData)
+	}()
+
+	// 1st matcher
+
+	cx.record()
+
+	n, err := cx.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(matcherData) {
+		t.Fatalf("expected to read %d bytes but got %d", len(matcherData), n)
+	}
+	if bytes.Compare(matcherData, buf) != 0 {
+		t.Fatalf("expected %s but received %s", matcherData, buf)
+	}
+
+	cx.rewind()
+
+	// 2nd matcher (reads same data)
+
+	cx.record()
+
+	n, err = cx.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(matcherData) {
+		t.Fatalf("expected to read %d bytes but got %d", len(matcherData), n)
+	}
+	if bytes.Compare(matcherData, buf) != 0 {
+		t.Fatalf("expected %s but received %s", matcherData, buf)
+	}
+
+	cx.rewind()
+
+	// 1st consumer (no record call)
+
+	n, err = cx.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(matcherData) {
+		t.Fatalf("expected to read %d bytes but got %d", len(matcherData), n)
+	}
+	if bytes.Compare(matcherData, buf) != 0 {
+		t.Fatalf("expected %s but received %s", matcherData, buf)
+	}
+
+	// 2nd consumer (reads other data)
+
+	n, err = cx.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(consumeData) {
+		t.Fatalf("expected to read %d bytes but got %d", len(consumeData), n)
+	}
+	if bytes.Compare(consumeData, buf) != 0 {
+		t.Fatalf("expected %s but received %s", consumeData, buf)
+	}
+}

--- a/layer4/matchers.go
+++ b/layer4/matchers.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -46,6 +47,18 @@ func (mset MatcherSet) Match(cx *Connection) (matched bool, err error) {
 		cx.record()
 		matched, err = m.Match(cx)
 		cx.rewind()
+		if cx.Logger.Core().Enabled(zap.DebugLevel) {
+			matcher := "unknown"
+			if cm, ok := m.(caddy.Module); ok {
+				matcher = cm.CaddyModule().String()
+			}
+			cx.Logger.Debug("matching",
+				zap.String("remote", cx.RemoteAddr().String()),
+				zap.Error(err),
+				zap.String("matcher", matcher),
+				zap.Bool("matched", matched),
+			)
+		}
 		if !matched || err != nil {
 			return
 		}

--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -128,6 +128,7 @@ func wrapRoute(route *Route, logger *zap.Logger) Middleware {
 			matched, err := route.matcherSets.AnyMatch(cx)
 			if err != nil {
 				logger.Error("matching connection", zap.String("remote", cx.RemoteAddr().String()), zap.Error(err))
+				return nil // return nil so the error does not get logged again
 			}
 			if !matched {
 				return nextCopy.Handle(cx)

--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -127,7 +127,7 @@ func wrapRoute(route *Route, logger *zap.Logger) Middleware {
 			// route must match at least one of the matcher sets
 			matched, err := route.matcherSets.AnyMatch(cx)
 			if err != nil {
-				logger.Error("matching connection", zap.Error(err))
+				logger.Error("matching connection", zap.String("remote", cx.RemoteAddr().String()), zap.Error(err))
 			}
 			if !matched {
 				return nextCopy.Handle(cx)

--- a/layer4/server.go
+++ b/layer4/server.go
@@ -100,13 +100,13 @@ func (s Server) handle(conn net.Conn) {
 	buf.Reset()
 	defer bufPool.Put(buf)
 
-	cx := WrapConnection(conn, buf)
+	cx := WrapConnection(conn, buf, s.logger)
 
 	start := time.Now()
 	err := s.compiledRoute.Handle(cx)
 	duration := time.Since(start)
 	if err != nil {
-		s.logger.Error("handling connection", zap.Error(err))
+		s.logger.Error("handling connection", zap.String("remote", cx.RemoteAddr().String()), zap.Error(err))
 	}
 
 	s.logger.Debug("connection stats",

--- a/modules/l4http/httpmatcher_test.go
+++ b/modules/l4http/httpmatcher_test.go
@@ -6,13 +6,15 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
-	"github.com/mholt/caddy-l4/layer4"
 	"io"
 	"net"
 	"sync"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
 )
 
 func assertNoError(t *testing.T, err error) {
@@ -31,7 +33,7 @@ func httpMatchTester(t *testing.T, matcherSets caddyhttp.RawMatcherSets, data []
 		_ = out.Close()
 	}()
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer func() {
@@ -200,7 +202,7 @@ func TestHttpMatchingByProtocolWithHttps(t *testing.T) {
 		_ = out.Close()
 	}()
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer func() {

--- a/modules/l4proxyprotocol/handler_test.go
+++ b/modules/l4proxyprotocol/handler_test.go
@@ -3,12 +3,14 @@ package l4proxyprotocol
 import (
 	"bytes"
 	"context"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/mholt/caddy-l4/layer4"
 	"io"
 	"net"
 	"sync"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
 )
 
 func assertString(t *testing.T, expected string, value string) {
@@ -23,7 +25,7 @@ func TestProxyProtocolHandleV1(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -61,7 +63,7 @@ func TestProxyProtocolHandleV2(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -99,7 +101,7 @@ func TestProxyProtocolHandleGarbage(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()

--- a/modules/l4proxyprotocol/matcher_test.go
+++ b/modules/l4proxyprotocol/matcher_test.go
@@ -3,11 +3,13 @@ package l4proxyprotocol
 import (
 	"bytes"
 	"encoding/hex"
-	"github.com/mholt/caddy-l4/layer4"
 	"io"
 	"net"
 	"sync"
 	"testing"
+
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
 )
 
 var ProxyV1Example = []byte("PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n")
@@ -31,7 +33,7 @@ func TestProxyProtocolMatchV1(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -57,7 +59,7 @@ func TestProxyProtocolMatchV2(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -83,7 +85,7 @@ func TestProxyProtocolMatchGarbage(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{})
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()

--- a/modules/l4socks/socks4_matcher_test.go
+++ b/modules/l4socks/socks4_matcher_test.go
@@ -3,11 +3,13 @@ package l4socks
 import (
 	"bytes"
 	"context"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/mholt/caddy-l4/layer4"
 	"io"
 	"net"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
 )
 
 func assertNoError(t *testing.T, err error) {
@@ -76,7 +78,7 @@ func TestSocks4Matcher_Match(t *testing.T) {
 				_ = out.Close()
 			}()
 
-			cx := layer4.WrapConnection(out, &bytes.Buffer{})
+			cx := layer4.WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
 			go func() {
 				_, err := in.Write(tc.data)
 				assertNoError(t, err)

--- a/modules/l4socks/socks5_handler_test.go
+++ b/modules/l4socks/socks5_handler_test.go
@@ -3,17 +3,19 @@ package l4socks
 import (
 	"bytes"
 	"context"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/mholt/caddy-l4/layer4"
 	"io"
 	"net"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
 )
 
 func replay(t *testing.T, handler *Socks5Handler, expectedError string, messages [][]byte) {
 	t.Helper()
 	in, out := net.Pipe()
-	cx := layer4.WrapConnection(out, &bytes.Buffer{})
+	cx := layer4.WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
 	defer func() {
 		_ = in.Close()
 		_, _ = io.Copy(io.Discard, out)

--- a/modules/l4socks/socks5_matcher_test.go
+++ b/modules/l4socks/socks5_matcher_test.go
@@ -3,11 +3,13 @@ package l4socks
 import (
 	"bytes"
 	"context"
-	"github.com/caddyserver/caddy/v2"
-	"github.com/mholt/caddy-l4/layer4"
 	"io"
 	"net"
 	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
 )
 
 func TestSocks5Matcher_Match(t *testing.T) {
@@ -53,7 +55,7 @@ func TestSocks5Matcher_Match(t *testing.T) {
 				_ = out.Close()
 			}()
 
-			cx := layer4.WrapConnection(out, &bytes.Buffer{})
+			cx := layer4.WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
 			go func() {
 				_, err := in.Write(tc.data)
 				assertNoError(t, err)

--- a/modules/l4tee/tee.go
+++ b/modules/l4tee/tee.go
@@ -103,7 +103,7 @@ func (t Handler) Handle(cx *layer4.Connection, next layer4.Handler) error {
 	go func() {
 		err := t.compiledChain.Handle(&branchc)
 		if err != nil {
-			t.logger.Error("handling connection in branch", zap.Error(err))
+			t.logger.Error("handling connection in branch", zap.String("remote", cx.RemoteAddr().String()), zap.Error(err))
 		}
 	}()
 


### PR DESCRIPTION
Hi,
my experiments mentioned in #68 revealed some bugs. I also added some more logging which makes debugging configs a lot easier.  

The first bug (at least I think it is one :smile:) is that when a matcher returns an error the processing is not stopped. Instead the next matcher is tried and if that matches its handlers are executed even if the connection is broken.

For example with this config
<details>
<summary>matcher-bug.json</summary>

```json
{
  "admin": {
    "disabled": true
  },
  "logging": {
    "logs": {
      "default": {"level":"DEBUG", "encoder": {"format":"console"}}
    }
  },
  "apps": {
    "layer4": {
      "servers": {
        "matcher": {
          "listen": ["0.0.0.0:8888"],
          "routes": [
            {
              "match": [
                {
                  "tls": {}
                }
              ],
              "handle": [
                {
                  "handler": "echo"
                }
              ]
            },
            {
              "match": [
                {
                  "ip": {"ranges": ["0.0.0.0/0"]}
                }
              ],
              "handle": [
                {
                  "handler": "proxy",
                  "upstreams": [{"dial": ["127.0.0.1:9999"]}]
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```

</details>

and this curl `curl -x socks5://127.0.0.1:8888 https://example.org` (Ctrl-C or wait 5 minutes for the timeout) you will get this confusing log:

```
1.6627550161737518e+09  info    serving initial configuration
1.662755029922435e+09   error   layer4  matching connection     {"error": "unexpected EOF"}
1.6627550319487917e+09  debug   layer4.handlers.proxy   dial upstream   {"remote": "10.0.0.2:43900", "upstream": "127.0.0.1:9999", "error": "dial tcp 127.0.0.1:9999: connectex: Es konnte keine Verbindung hergestellt werden, da der Zielcomputer die Verbindung verweigerte."}
1.662755031949321e+09   error   layer4  handling connection     {"error": "dial tcp 127.0.0.1:9999: connectex: Es konnte keine Verbindung hergestellt werden, da der Zielcomputer die Verbindung verweigerte."}
1.662755031949321e+09   debug   layer4  connection stats        {"remote": "10.0.0.2:43900", "read": 4, "written": 0, "duration": 6.8051304}
```

with the fixes and additional logging it looks like this:
```
1.6627555421950946e+09  info    serving initial configuration
1.6627555549489841e+09  debug   layer4  matching        {"remote": "10.0.0.2:35720", "error": "unexpected EOF", "matcher": "layer4.matchers.tls", "matched": false}
1.6627555549492755e+09  error   layer4  matching connection     {"remote": "10.0.0.2:35720", "error": "unexpected EOF"}
1.6627555549492755e+09  debug   layer4  connection stats        {"remote": "10.0.0.2:35720", "read": 4, "written": 0, "duration": 3.2630775}
```
Only one matcher and no handlers are executed.


The second bug is causing `Read()` to return 0 bytes and no error on its first call after `record()` (which I also mentioned [here](https://github.com/mholt/caddy-l4/pull/68#issuecomment-1239907686)). It's probably not forbidden for an `io.Reader` to do that but its confusing. I wrote a connection test that covers this situation `TestConnection_RecordAndRewind`.

The additional remote ip address logging is mainly intended as kind of connection id, with that its possible to correlate multiple log lines on busy servers.


Besides that I also have a commit which adds a per route configurable matching timeout. But it needs more testing and is probably better discussed in its own PR.

I am also still experimenting on how to prevent matchers from blocking when there is not enough data for them. But I would like to see these fixes merged first, so I can work on top of them. A short read detection in the layer4 connection looks promising. One problem is the http matcher. Since it uses a buffered reader, it will always cause a short read from the view point of the connection.