### PR TITLE
Non blocking matchers & matching timeout

### DIFF
--- a/layer4/connection_test.go
+++ b/layer4/connection_test.go
@@ -13,7 +13,7 @@ func TestConnection_RecordAndRewind(t *testing.T) {
 	defer in.Close()
 	defer out.Close()
 
-	cx := WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
+	cx := WrapConnection(out, []byte{}, zap.NewNop())
 	defer cx.Close()
 
 	matcherData := []byte("foo")

--- a/layer4/listener.go
+++ b/layer4/listener.go
@@ -1,15 +1,15 @@
 package layer4
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"github.com/caddyserver/caddy/v2"
-	"go.uber.org/zap"
 	"net"
 	"runtime"
 	"sync"
 	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -115,8 +115,8 @@ func (l *listener) handle(conn net.Conn) {
 		}
 	}()
 
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
+	buf := bufPool.Get().([]byte)
+	buf = buf[:0]
 	defer bufPool.Put(buf)
 
 	cx := WrapConnection(conn, buf, l.logger)

--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -146,6 +146,10 @@ func wrapRoute(route *Route, logger *zap.Logger) Middleware {
 
 			// route must match at least one of the matcher sets
 			matched, err := route.matcherSets.AnyMatch(cx)
+			if err == ErrConsumedAllPrefetchedBytes {
+				matched = false
+				err = nil
+			}
 			if err != nil {
 				if errors.Is(err, os.ErrDeadlineExceeded) {
 					err = ErrMatchingTimeout

--- a/layer4/routes_test.go
+++ b/layer4/routes_test.go
@@ -1,0 +1,122 @@
+package layer4
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type testMatcher struct {
+	Called bool
+}
+
+func (testMatcher) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.matchers.test",
+		New: func() caddy.Module { return new(testMatcher) },
+	}
+}
+
+func (*testMatcher) Provision(_ caddy.Context) (err error) {
+	return nil
+}
+
+func (m *testMatcher) Match(cx *Connection) (bool, error) {
+	m.Called = true
+	buf := make([]byte, 1)
+	_, err := cx.Read(buf)
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+type sentinelHandler struct {
+	Called bool
+}
+
+func (h *sentinelHandler) Handle(_ *Connection) error {
+	h.Called = true
+	return nil
+}
+
+func TestMatchingTimeoutWorks(t *testing.T) {
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	defer cancel()
+
+	caddy.RegisterModule(testMatcher{})
+
+	route := &Route{
+		MatcherSetsRaw: []caddy.ModuleMap{
+			{"test": json.RawMessage("{}")},
+			{"test": json.RawMessage("{}")},
+		},
+	}
+	routes := RouteList{route}
+
+	err := routes.Provision(ctx)
+	if err != nil {
+		t.Fatalf("provision failed | %s", err)
+	}
+
+	// verify Provision sets a default value
+	if route.MatchingTimeout <= 0 {
+		t.Fatalf("matching timeout should have a default > 0 but got %v", route.MatchingTimeout)
+	}
+	// overwrite default with very short value for fast test
+	route.MatchingTimeout = caddy.Duration(5 * time.Millisecond)
+
+	sentinel := &sentinelHandler{}
+	loggerCore, logs := observer.New(zapcore.ErrorLevel)
+	compiledRoutes := routes.Compile(sentinel, zap.New(loggerCore))
+
+	in, out := net.Pipe()
+	defer in.Close()
+	defer out.Close()
+
+	cx := WrapConnection(out, []byte{}, zap.NewNop())
+	defer cx.Close()
+
+	err = compiledRoutes.Handle(cx)
+	if err != nil {
+		t.Fatalf("unexpected handler error | %v", err)
+	}
+
+	// verify the matching aborted error was logged
+	if logs.Len() != 1 {
+		t.Fatalf("logs should contain 1 entry but has %d", logs.Len())
+	}
+	logEntry := logs.All()[0]
+	if logEntry.Level != zapcore.ErrorLevel {
+		t.Fatalf("wrong log level | %s", logEntry.Level)
+	}
+	if logEntry.Message != "matching connection" {
+		t.Fatalf("wrong log message | %s", logEntry.Message)
+	}
+	if !(logEntry.Context[1].Key == "error" && errors.Is(logEntry.Context[1].Interface.(error), ErrMatchingTimeout)) {
+		t.Fatalf("wrong error | %v", logEntry.Context[1].Interface)
+	}
+
+	// 1st matcher was called but should produce a timeout error
+	if route.matcherSets[0][0].(*testMatcher).Called != true {
+		t.Fatal("test matcher 1 was not called but should")
+	}
+
+	// 2nd matcher should not be called because 1st matcher produced an error
+	if route.matcherSets[1][0].(*testMatcher).Called != false {
+		t.Fatal("test matcher 2 was called but should not")
+	}
+
+	// since matching failed no handler should be called
+	if sentinel.Called != false {
+		t.Fatal("sentinel handler was called but should not")
+	}
+}

--- a/layer4/server.go
+++ b/layer4/server.go
@@ -96,8 +96,8 @@ func (s Server) servePacket(pc net.PacketConn) error {
 func (s Server) handle(conn net.Conn) {
 	defer conn.Close()
 
-	buf := bufPool.Get().(*bytes.Buffer)
-	buf.Reset()
+	buf := bufPool.Get().([]byte)
+	buf = buf[:0]
 	defer bufPool.Put(buf)
 
 	cx := WrapConnection(conn, buf, s.logger)

--- a/modules/l4http/httpmatcher.go
+++ b/modules/l4http/httpmatcher.go
@@ -16,17 +16,19 @@ package l4http
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/mholt/caddy-l4/layer4"
 	"github.com/mholt/caddy-l4/modules/l4tls"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
-	"io"
-	"net/http"
-	"net/url"
 )
 
 func init() {
@@ -78,11 +80,18 @@ func (m MatchHTTP) Match(cx *layer4.Connection) (bool, error) {
 	req, ok := cx.GetVar("http_request").(*http.Request)
 	if !ok {
 		var err error
-		bufReader := bufio.NewReader(cx)
+
+		data, err := cx.MatchingBytes()
+		if !m.isHttp(data) {
+			return false, nil
+		}
+
+		// use bufio reader which exactly matches the size of prefetched data,
+		// to not trigger all bytes consumed error
+		bufReader := bufio.NewReaderSize(cx, len(data))
 		req, err = http.ReadRequest(bufReader)
 		if err != nil {
-			// TODO: find a way to distinguish actual errors from mismatches
-			return false, nil
+			return false, err
 		}
 
 		// check if req is a http2 request made with prior knowledge and if so parse it
@@ -111,6 +120,23 @@ func (m MatchHTTP) Match(cx *layer4.Connection) (bool, error) {
 	// we have a valid HTTP request, so we can drill down further if there are
 	// any more matchers configured
 	return m.matcherSets.AnyMatch(req), nil
+}
+
+func (m MatchHTTP) isHttp(data []byte) bool {
+	// try to find the end of a http request line, for example " HTTP/1.1\r\n"
+	i := bytes.IndexByte(data, 0x0a) // find first new line
+	if i < 10 {
+		return false
+	}
+	// assume only \n line ending
+	start := i - 9 // position of space in front of HTTP
+	end := i - 3   // cut off version number "1.1" or "2.0"
+	// if we got a correct \r\n line ending shift the calculated start & end to the left
+	if data[i-1] == 0x0d {
+		start -= 1
+		end -= 1
+	}
+	return bytes.Compare(data[start:end], []byte(" HTTP/")) == 0
 }
 
 // Parses information from a http2 request with prior knowledge (RFC 7540 Section 3.4)

--- a/modules/l4proxyprotocol/handler_test.go
+++ b/modules/l4proxyprotocol/handler_test.go
@@ -1,7 +1,6 @@
 package l4proxyprotocol
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"net"
@@ -25,7 +24,7 @@ func TestProxyProtocolHandleV1(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -63,7 +62,7 @@ func TestProxyProtocolHandleV2(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -101,7 +100,7 @@ func TestProxyProtocolHandleGarbage(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()

--- a/modules/l4proxyprotocol/matcher_test.go
+++ b/modules/l4proxyprotocol/matcher_test.go
@@ -1,7 +1,6 @@
 package l4proxyprotocol
 
 import (
-	"bytes"
 	"encoding/hex"
 	"io"
 	"net"
@@ -33,7 +32,7 @@ func TestProxyProtocolMatchV1(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -59,7 +58,7 @@ func TestProxyProtocolMatchV2(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()
@@ -85,7 +84,7 @@ func TestProxyProtocolMatchGarbage(t *testing.T) {
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 	go func() {
 		wg.Add(1)
 		defer wg.Done()

--- a/modules/l4socks/socks4_matcher_test.go
+++ b/modules/l4socks/socks4_matcher_test.go
@@ -1,7 +1,6 @@
 package l4socks
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"net"
@@ -78,7 +77,7 @@ func TestSocks4Matcher_Match(t *testing.T) {
 				_ = out.Close()
 			}()
 
-			cx := layer4.WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
+			cx := layer4.WrapConnection(out, []byte{}, zap.NewNop())
 			go func() {
 				_, err := in.Write(tc.data)
 				assertNoError(t, err)

--- a/modules/l4socks/socks5_handler_test.go
+++ b/modules/l4socks/socks5_handler_test.go
@@ -17,7 +17,7 @@ import (
 func replay(t *testing.T, handler *Socks5Handler, expectedError string, messages [][]byte) {
 	t.Helper()
 	in, out := net.Pipe()
-	cx := layer4.WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(out, []byte{}, zap.NewNop())
 	defer func() {
 		_ = in.Close()
 		_, _ = io.Copy(io.Discard, out)

--- a/modules/l4socks/socks5_matcher_test.go
+++ b/modules/l4socks/socks5_matcher_test.go
@@ -1,7 +1,6 @@
 package l4socks
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"net"
@@ -55,7 +54,7 @@ func TestSocks5Matcher_Match(t *testing.T) {
 				_ = out.Close()
 			}()
 
-			cx := layer4.WrapConnection(out, &bytes.Buffer{}, zap.NewNop())
+			cx := layer4.WrapConnection(out, []byte{}, zap.NewNop())
 			go func() {
 				_, err := in.Write(tc.data)
 				assertNoError(t, err)


### PR DESCRIPTION
Hi,
this is my best attempt to solve the blocking matchers problem when clients send not enough data (also discussed in #68).  
In the end it is a full rewrite of the layer4 connection. It now has a `prefetch` function which tries to load all data a client sends during connection setup. It does this in chunks of 1024 bytes up to 8 KiB and stops on the first short read.  
During matching a `ErrConsumedAllPrefetchedBytes` is returned if a matcher requests more data than currently available. If the routing code see this error it is ignored and the next matcher is tried.  

The only matcher that does not play well with this is the http matcher because `http.ReadRequest` forces us to use a `bufio.Reader`. That's why I also added a `MatchingBytes` function which allows matcher to get a view of all available bytes. The http matcher uses this to pre check if the data looks like http before calling `http.ReadRequest` and also to configure the buffer size for the `bufio.Reader` so it does not produce the `ErrConsumedAllPrefetchedBytes` error.  
It's a bit hacky and can probably be improved.

The matching timeout is implemented by setting `SetReadDeadline` before each matcher and can be configured per route.

There are still many things to do, this is just so you can take a peek.
1. I am not sure if the nested timeout config is necessary, Maybe move it up and rename it to `matcher_timeout`?
2. Should the max prefetch/matching byte size be configurable?
3. Fix the tests. `net.Pipe` behaves very differently from a real connection, it does not return short reads and so the prefetching breaks.
4. And probably write some more tests 😄 