### PR TITLE
fix #78

### DIFF
--- a/layer4/listener.go
+++ b/layer4/listener.go
@@ -119,7 +119,7 @@ func (l *listener) handle(conn net.Conn) {
 	buf.Reset()
 	defer bufPool.Put(buf)
 
-	cx := WrapConnection(conn, buf)
+	cx := WrapConnection(conn, buf, l.logger)
 	cx.Context = context.WithValue(cx.Context, listenerCtxKey, l)
 
 	start := time.Now()


### PR DESCRIPTION
```
2022/11/30 06:53:48 [INFO] exec (timeout=0s): /usr/local/go/bin/go build -o /go/bin/caddy-with-cfdns-geoip-proxyproto-l4-aaa-naiveproxy -ldflags -w -s -trimpath
# github.com/mholt/caddy-l4/layer4
/go/pkg/mod/github.com/mholt/caddy-l4@v0.0.0-20221129181354-1c1f62d5c914/layer4/listener.go:122:29: not enough arguments in call to WrapConnection
        have (net.Conn, *bytes.Buffer)
        want (net.Conn, *bytes.Buffer, *zap.Logger)
```