### PR TITLE
Overhaul UDP server

### DIFF
--- a/layer4/server.go
+++ b/layer4/server.go
@@ -143,6 +143,10 @@ func (pc packetConn) RemoteAddr() net.Addr { return pc.addr }
 
 var udpBufPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, 1024)
+		// Buffers need to be as large as the largest datagram we'll consume, because
+		// ReadFrom() can't resume partial reads.  (This is standard for UDP
+		// sockets on *nix.)  So our buffer sizes are 9000 bytes to accommodate
+		// networks with jumbo frames.  See also https://github.com/golang/go/issues/18056
+		return make([]byte, 9000)
 	},
 }


### PR DESCRIPTION
Following up from #140, the UDP server implementation has two fatal flaws:

1. UDP buffers were too small, resulting in truncated data being forwarded to upstreams for datagrams exceeding 1024 bytes (the buffer size)
2. A goroutine was created per-packet that called the proxy handler but never terminated

1 is an easy enough fix.  2 is addressed by this PR in the following way:

* UDP "connections" are tracked in a map called `udpConns` (keyed on downstream client addr:port) for the given UDP server port
* When a new packet is received by a UDP server, the `udpConns` map is checked for that remote `addr:port`. 
    * If it doesn't exist:
       * a new `packetConn` is created for that downstream and a goroutine is created to call the long-running proxy handler
       * `packetConn` has been updated to include additional fields to allow for communication with the UDP server
       * Notably, there's a channel for `packetConn` to read new packets from the server for this particular downstream, and there's a channel for it to communicate back to the UDP server that the connection has been closed.
       * (This latter case allows the UDP server loop to both add and remove elements from the `udpConns` map, which avoids the need to acquire a mutex for each packet.)
    * If it does exist:
       * the packet is send to the `packetConn`'s packet channel
* `packetConn` now has the concept of an idle timeout.  If no new packets are received from the downstream within a period of time (currently hardcoded) then the connection is considered closed.  Any pending `Read()` call is immediately returned with io.EOF, which in turn causes the upstream connections to be closed, which allows the handler (and the per-connection goroutine which called it) to terminate.

I've tested this with HTTP/3 (with QUIC-enabled nginx and curl).  Problem 1 stopped the current master branch dead in its tracks, since it couldn't get past the initial handshake (due to the first packet being 1200 bytes, which got truncated by the 1024 byte buffer).

Even after fixing that in master, the QUIC handshake didn't complete because each new packet from the downstream would be forwarded to the upstream from a different source port, so the QUIC server side saw them as unrelated packets.

With this PR, curl is able to fetch via caddy to the nginx upstream, both short requests as well as bulk downloads.  Performance isn't brilliant, it must be said: with all 3 things (curl, caddy, nginx) running on the same box, caddy runs around 200-220% CPU in order to bottleneck nginx, which has a single thread bottleneck so runs at 98%+.   The nginx bottleneck caps effective throughput to about 70-80MB/s.  Disappointing results from QUIC there, but not Caddy's fault. :)

But it *works*, which is an already an improvement.

Pending problems:
 1. Channel buffer lengths are hardcoded and need some further consideration
 2. UDP connection idle timeout is currently hardcoded, but should probably be configurable per server
 3. Existing UDP connections are borked by config reloads

The last problem is the biggest obstacle right now, and I'm not really sure how to fix it.  Here's what happens:
* `Handler.proxy()` is diligently doing `io.Copy()` for upstream->downstream and downstream->upstream (in separate goroutines)
* When config is reloaded, thanks to #132, the server UDP socket is closed, which allows the UDP server loop to terminate
* But because the original UDP server socket is closed, the `io.Copy()` invocations both immediately abort with "use of closed network connection"
* Consequently the QUIC transfer abruptly stalls out and the client needs to reconnect

This isn't a problem for TCP, because we get a separate socket representing the TCP connection that's independent from the listen socket.  This isn't the case for UDP, where incoming data from all downstreams is always received over the same socket, so any in-flight handlers proxying data between upstream/downstream depend on this socket continuing to exist.

This is a consequence of how config reloading is done in general within Caddy, so I think I'll need to depend on your suggestions at this point.  It's the main thing keeping this PR in draft status -- although even with that problem, the code in the PR still significantly improves UDP proxying behavior with caddy-l4.