### PR TITLE
Add tls.handshake_match.version matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Current matchers:
 - **layer4.matchers.socks4** - matches connections that look like [SOCKSv4](https://www.openssh.com/txt/socks4.protocol).
 - **layer4.matchers.socks5** - matches connections that look like [SOCKSv5](https://www.rfc-editor.org/rfc/rfc1928.html).
 - **tls.handshake_match.version** - matches TLS Version from ClientHello, using strings from [VersionName](https://go.dev/src/crypto/tls/common.go).
+
 Current handlers:
 
 - **layer4.handlers.echo** - An echo server.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Current matchers:
 - **layer4.matchers.proxy_protocol** - matches connections that start with [HAPROXY proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt).
 - **layer4.matchers.socks4** - matches connections that look like [SOCKSv4](https://www.openssh.com/txt/socks4.protocol).
 - **layer4.matchers.socks5** - matches connections that look like [SOCKSv5](https://www.rfc-editor.org/rfc/rfc1928.html).
-
+- **tls.handshake_match.version** - matches TLS Version from ClientHello, using strings from [VersionName](https://go.dev/src/crypto/tls/common.go).
 Current handlers:
 
 - **layer4.handlers.echo** - An echo server.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/agittins/caddy-l4
+module github.com/mholt/caddy-l4
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mholt/caddy-l4
+module github.com/agittins/caddy-l4
 
 go 1.20
 

--- a/modules/l4tls/version_matcher.go
+++ b/modules/l4tls/version_matcher.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4tls
+
+import (
+	"crypto/tls"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddytls"
+)
+
+func init() {
+	caddy.RegisterModule(MatchVersion{})
+}
+
+type MatchVersion []string
+
+// CaddyModule returns the Caddy module information.
+func (MatchVersion) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "tls.handshake_match.version",
+		New: func() caddy.Module { return new(MatchVersion) },
+	}
+}
+
+// Match against connection TLS "Version" by name. Eg: "TLS 1.0"
+// See https://go.dev/src/crypto/tls/common.go
+func (m MatchVersion) Match(hello *tls.ClientHelloInfo) bool {
+	clientVersions := hello.SupportedVersions
+	for _, mVersion := range m {
+		for _, clientVersion := range clientVersions {
+			if mVersion == tls.VersionName(clientVersion) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Interface guards
+var (
+	_ caddytls.ConnectionMatcher = (*MatchVersion)(nil)
+)


### PR DESCRIPTION
- creates a new matcher, tls.handshake_match.version
- based heavily on the alpn matcher.