### PR TITLE
L4 module for Postgres: matchers

### DIFF
--- a/modules/l4postgres/matcher.go
+++ b/modules/l4postgres/matcher.go
@@ -77,8 +77,13 @@ type startupMessage struct {
 	Parameters      map[string]string
 }
 
-// MatchPostgres is able to match Postgres connections.
-type MatchPostgres struct{}
+// MatchPostgres is able to match Postgres connections, optionally further
+// matching on the User or Database being requested
+type MatchPostgres struct {
+	Users     []string
+	Databases []string
+	startup   *startupMessage
+}
 
 // CaddyModule returns the Caddy module information.
 func (MatchPostgres) CaddyModule() caddy.ModuleInfo {
@@ -116,7 +121,7 @@ func (m MatchPostgres) Match(cx *layer4.Connection) (bool, error) {
 	}
 
 	// Try parsing Postgres Params
-	startup := &startupMessage{ProtocolVersion: code, Parameters: make(map[string]string)}
+	m.startup = &startupMessage{ProtocolVersion: code, Parameters: make(map[string]string)}
 	for {
 		k := b.ReadString()
 		if k == "" {

--- a/modules/l4postgres/matcher_test.go
+++ b/modules/l4postgres/matcher_test.go
@@ -47,7 +47,7 @@ func matchTester(t *testing.T, matcher layer4.ConnMatcher, data []byte) (bool, e
 	in, out := net.Pipe()
 	defer closePipe(wg, in, out)
 
-	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+	cx := layer4.WrapConnection(in, []byte{}, zap.NewNop())
 
 	wg.Add(1)
 	go func() {

--- a/modules/l4postgres/matcher_test.go
+++ b/modules/l4postgres/matcher_test.go
@@ -75,8 +75,6 @@ func Fatalf(t *testing.T, err error, matched bool, expect bool, explain string) 
 }
 
 func TestPostgres(t *testing.T) {
-	t.Parallel() // marks as capable of running in parallel with other tests
-
 	// ref: https://go.dev/wiki/TableDrivenTests
 	tests := []struct {
 		name    string
@@ -135,8 +133,6 @@ func TestPostgres(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // NOTE: /wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			data, err := tc.data.Read()
 			assertNoError(t, err)
 
@@ -147,8 +143,6 @@ func TestPostgres(t *testing.T) {
 }
 
 func TestPostgresSSL(t *testing.T) {
-	t.Parallel() // marks as capable of running in parallel with other tests
-
 	// ref: https://go.dev/wiki/TableDrivenTests
 	tests := []struct {
 		name    string
@@ -244,8 +238,6 @@ func TestPostgresSSL(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc // NOTE: /wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			data, err := tc.data.Read()
 			assertNoError(t, err)
 

--- a/modules/l4postgres/matcher_test.go
+++ b/modules/l4postgres/matcher_test.go
@@ -1,0 +1,124 @@
+package l4postgres
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/mholt/caddy-l4/layer4"
+	"go.uber.org/zap"
+)
+
+// Example extends StartupMessage with utils to create example messages.
+type example struct {
+	startupMessage
+}
+
+// Bytes gets []byte from a struct as the raw protocol is similar to
+// "user\u0000alice\u0000database\u0000stars_db"
+func (x *example) Bytes() []byte {
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(x.Reader())
+	return buf.Bytes()
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Unexpected error: %s\n", err)
+	}
+}
+
+func closePipe(wg *sync.WaitGroup, c1 net.Conn, c2 net.Conn) {
+	wg.Wait()
+	_ = c1.Close()
+	_ = c2.Close()
+}
+
+var ExampleSSLRequest = func() []byte {
+	x := &example{
+		startupMessage: startupMessage{
+			ProtocolVersion: sslRequestCode,
+		},
+	}
+	return x.Bytes()
+}
+
+var ExampleStartupMessage = func() []byte {
+	x := &example{
+		startupMessage: startupMessage{
+			ProtocolVersion: 196608, // v3.0
+			Parameters: map[string]string{
+				"user":     "alice",
+				"database": "stars_db",
+			},
+		},
+	}
+	return x.Bytes()
+}
+
+func TestPostgresSSLMatch(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	in, out := net.Pipe()
+	defer closePipe(wg, in, out)
+
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+
+	x := ExampleSSLRequest()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer out.Close()
+		_, err := out.Write(x)
+		assertNoError(t, err)
+	}()
+
+	matcher := MatchPostgresSSL{
+		Required: true,
+	}
+
+	matched, err := matcher.Match(cx)
+	assertNoError(t, err)
+
+	if !matched {
+		t.Fatalf("matcher did not match SSL")
+	}
+
+	_, _ = io.Copy(io.Discard, in)
+}
+
+func TestPostgresMatch(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	in, out := net.Pipe()
+	defer closePipe(wg, in, out)
+
+	cx := layer4.WrapConnection(in, &bytes.Buffer{}, zap.NewNop())
+
+	x := ExampleStartupMessage()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer out.Close()
+		_, err := out.Write(x)
+		assertNoError(t, err)
+	}()
+
+	matcher := MatchPostgres{
+		Users: map[string][]string{
+			"alice": {},
+		},
+	}
+
+	matched, err := matcher.Match(cx)
+	assertNoError(t, err)
+
+	if !matched {
+		t.Fatalf("matcher did not match user")
+	}
+
+	_, _ = io.Copy(io.Discard, in)
+}

--- a/modules/l4postgres/matcher_test.go
+++ b/modules/l4postgres/matcher_test.go
@@ -11,8 +11,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// Reader allows any Example to be used in tests as data
-type Reader interface {
+// MessageReader allows any Example to be used in tests as data
+type MessageReader interface {
 	Read() ([]byte, error)
 }
 
@@ -81,7 +81,7 @@ func TestPostgres(t *testing.T) {
 	tests := []struct {
 		name    string
 		matcher layer4.ConnMatcher
-		data    Reader
+		data    MessageReader
 		expect  bool
 		explain string
 	}{
@@ -153,7 +153,7 @@ func TestPostgresSSL(t *testing.T) {
 	tests := []struct {
 		name    string
 		matcher layer4.ConnMatcher
-		data    Reader
+		data    MessageReader
 		expect  bool
 		explain string
 	}{

--- a/modules/l4postgres/messages.go
+++ b/modules/l4postgres/messages.go
@@ -1,0 +1,142 @@
+// ref: https://github.com/rueian/pgbroker/blob/master/message/util.go
+package l4postgres
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+)
+
+const (
+	// byte size of the message length field
+	lengthFieldSize = 4
+)
+
+// Message provides readers for various types and
+// updates the offset after each read/write operation.
+type message struct {
+	data   []byte
+	offset uint32
+}
+
+func (b *message) ReadUint32() (r uint32) {
+	r = binary.BigEndian.Uint32(b.data[b.offset : b.offset+4])
+	b.offset += 4
+	return r
+}
+
+func (b *message) ReadString() (r string) {
+	end := b.offset
+	max := uint32(len(b.data))
+	for ; end != max && b.data[end] != 0; end++ {
+	}
+	r = string(b.data[b.offset:end])
+	b.offset = end + 1
+	return r
+}
+
+func (b *message) WriteByte(i byte) {
+	b.data[b.offset] = i
+	b.offset++
+}
+
+func (b *message) WriteByteN(i []byte) {
+	for _, s := range i {
+		b.WriteByte(s)
+	}
+}
+
+func (b *message) WriteUint32(i uint32) {
+	binary.BigEndian.PutUint32(b.data[b.offset:b.offset+4], i)
+	b.offset += 4
+}
+
+func (b *message) WriteString(i string) {
+	b.WriteByteN([]byte(i))
+	b.WriteByte(0)
+}
+
+func (b *message) Length() int {
+	return len(b.data)
+}
+
+func (b *message) Reader() io.Reader {
+	length := make([]byte, lengthFieldSize)
+	binary.BigEndian.PutUint32(length, uint32(b.Length()+lengthFieldSize))
+	return io.MultiReader(
+		bytes.NewReader(length),
+		bytes.NewReader(b.data),
+	)
+}
+
+func newMessage(len int) *message {
+	return &message{data: make([]byte, len)}
+}
+
+// NewMessageFromBytes wraps the raw bytes of a message to enable processing
+func newMessageFromBytes(b []byte) *message {
+	return &message{data: b}
+}
+
+// StartupMessage contains the values parsed from the first message received.
+// This should be either a SSLRequest or StartupMessage
+type startupMessage struct {
+	ProtocolVersion uint32
+	Parameters      map[string]string
+}
+
+func (m *startupMessage) Reader() io.Reader {
+	length := lengthFieldSize
+	for k, v := range m.Parameters {
+		length += len(k) + 1
+		length += len(v) + 1
+	}
+	length += 1
+	b := newMessage(length)
+	b.WriteUint32(m.ProtocolVersion)
+	for k, v := range m.Parameters {
+		b.WriteString(k)
+		b.WriteString(v)
+	}
+	b.WriteByte(0)
+	return b.Reader()
+}
+
+// IsSSL confirms this is a SSLRequest
+func (s startupMessage) IsSSL() bool {
+	return isSSLRequest(s.ProtocolVersion)
+}
+
+// IsSupported confirms this is a supported version of Postgres
+func (s startupMessage) IsSupported() bool {
+	return isSupported(s.ProtocolVersion)
+}
+
+// NewStartupMessage creates a new startupMessage from the message bytes
+func newStartupMessage(b *message) *startupMessage {
+	return &startupMessage{
+		ProtocolVersion: b.ReadUint32(),
+		Parameters:      parseParameters(b),
+	}
+}
+
+func isSSLRequest(code uint32) bool {
+	return code == sslRequestCode
+}
+
+func isSupported(code uint32) bool {
+	majorVersion := code >> 16
+	return majorVersion >= 3
+}
+
+func parseParameters(b *message) map[string]string {
+	params := make(map[string]string)
+	for {
+		k := b.ReadString()
+		if k == "" {
+			break
+		}
+		params[k] = b.ReadString()
+	}
+	return params
+}

--- a/modules/l4postgres/messages_test.go
+++ b/modules/l4postgres/messages_test.go
@@ -1,0 +1,18 @@
+package l4postgres
+
+import "testing"
+
+func TestIsSSLRequest(t *testing.T) {
+	if !isSSLRequest(80877103) {
+		t.Fatalf("magic SSL number is not recognised")
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	if isSupported(1234) {
+		t.Fatalf("protocol version should require > v3.0")
+	}
+	if !isSupported(196608) { // v3.0
+		t.Fatalf("protocol version should require > v3.0")
+	}
+}


### PR DESCRIPTION
This PR adds additional matchers for the Postgres module:

1. Postgres Matcher can now match on the combination of `user` and `database` parameters when SSL is disabled
2. New PostgresClient Matcher that checks the `application_name` parameter when SSL is disabled
3. New PostgresSSL Matcher that can enforce/reject the use of SSL connections, but cannot match on their content

More tests and docs are in progress, but given the discussion in https://github.com/mholt/caddy-l4/issues/187 I'd like to share the non-SSL matchers, and discuss further enhancements to the PostgresSSL Matcher