### PR TITLE
handlers(l4proxy): add use_client_config to l4proxy upstream conf

### DIFF
--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -201,7 +201,7 @@ func (h *Handler) dialPeers(upstream *Upstream, repl *caddy.Replacer, down *laye
 			// in which case we adopt the downstream client's TLS ClientHello for ours;
 			// i.e. by default, make the client's TLS config as transparent as possible
 			tlsCfg := upstream.tlsConfig
-			if tlsCfg == nil {
+			if tlsCfg == nil || upstream.TLS.PropagateClientConfig {
 				tlsCfg = new(tls.Config)
 				if hellos := l4tls.GetClientHelloInfos(down); len(hellos) > 0 {
 					hellos[0].FillTLSClientConfig(tlsCfg)

--- a/modules/l4proxy/upstream.go
+++ b/modules/l4proxy/upstream.go
@@ -27,6 +27,14 @@ import (
 // UpstreamPool is a collection of upstreams.
 type UpstreamPool []*Upstream
 
+type UpstreamTLSConfig struct {
+	reverseproxy.TLSConfig
+
+	// Propagate TLS configuration of the client to for the upstream connection
+	// Setting this to true resembles default behvior when TLS configuration is nil
+	PropagateClientConfig bool `json:"use_client_config,omitempty"`
+}
+
 // Upstream represents a proxy upstream.
 type Upstream struct {
 	// The network addresses to dial. Supports placeholders, but not port
@@ -34,7 +42,7 @@ type Upstream struct {
 	Dial []string `json:"dial,omitempty"`
 
 	// Set this field to enable TLS to the upstream.
-	TLS *reverseproxy.TLSConfig `json:"tls,omitempty"`
+	TLS *UpstreamTLSConfig `json:"tls,omitempty"`
 
 	// How many connections this upstream is allowed to
 	// have before being marked as unhealthy (if > 0).


### PR DESCRIPTION
The TLS client configuration for `proxy` `upstreams` considers the downstream connectino values only if configured empty.

This adds a new configuration value `use_client_conf`, which allows preserving this behavior despite configuring the `tls` field.
