### PR TITLE
remove unnecessary routes matching and restore old fallback next hand…

### DIFF
--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -209,6 +209,8 @@ func (cx *Connection) GetVar(key string) interface{} {
 
 // MatchingBytes returns all bytes currently available for matching. This is only intended for reading.
 // Do not write into the slice. It's a view of the internal buffer, and you will likely mess up the connection.
+// Use of this for matching purpose should be accompanied by corresponding error value,
+// ErrConsumedAllPrefetchedBytes and ErrMatchingBufferFull, if not matched.
 func (cx *Connection) MatchingBytes() []byte {
 	return cx.buf[cx.offset:]
 }

--- a/layer4/handlers.go
+++ b/layer4/handlers.go
@@ -80,13 +80,16 @@ type nopHandler struct{}
 
 func (nopHandler) Handle(_ *Connection) error { return nil }
 
-type nopNextHandler struct{}
+// forwardNextHandler will forward the handling to the next handler in the chain.
+type forwardNextHandler struct{}
 
-func (nopNextHandler) Handle(cx *Connection, next Handler) error { return next.Handle(cx) }
+func (forwardNextHandler) Handle(cx *Connection, next Handler) error {
+	return next.Handle(cx)
+}
 
 // listenerHandler is a connection handler that pipe incoming connection to channel as a listener wrapper
 type listenerHandler struct{}
 
-func (listenerHandler) Handle(conn *Connection, _ Handler) error {
+func (listenerHandler) Handle(conn *Connection) error {
 	return conn.Context.Value(listenerCtxKey).(*listener).pipeConnection(conn)
 }

--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -73,7 +73,6 @@ func (r *Route) Provision(ctx caddy.Context) error {
 	for _, midhandler := range handlers {
 		r.middleware = append(r.middleware, wrapHandler(midhandler))
 	}
-
 	return nil
 }
 
@@ -95,51 +94,62 @@ func (routes RouteList) Provision(ctx caddy.Context) error {
 	return nil
 }
 
+const (
+	// routes that need more data to determine the match
+	routeNeedsMore = iota
+	// routes definitely not matched
+	routeNotMatched
+	routeMatched
+)
+
 // Compile prepares a middleware chain from the route list.
 // This should only be done once: after all the routes have
 // been provisioned, and before the server loop begins.
-func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duration, next NextHandler) Handler {
+func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duration, next Handler) Handler {
 	return HandlerFunc(func(cx *Connection) error {
 		deadline := time.Now().Add(matchingTimeout)
-		lastMatchedRouteIdx := -1
-	router:
+
+		var (
+			lastMatchedRouteIdx = -1
+			routesStatus        = make(map[int]int)
+		)
+		// this loop should only be done if there are matchers that can't determine the match,
+		// i.e. some of the matchers returned false, ErrConsumedAllPrefetchedBytes. The index which
+		// the loop begins depends upon if there is a matched route.
+	loop:
 		// timeout matching to protect against malicious or very slow clients
 		err := cx.Conn.SetReadDeadline(deadline)
 		if err != nil {
 			return err
 		}
-
-		for i := 0; i < 10000; i++ { // retry prefetching and matching routes until timeout
-
-			// Do not call prefetch if this is the first loop iteration and there already is some data available,
-			// since this means we are at the start of a subroute handler and previous prefetch calls likely already fetched all bytes available from the client.
-			// Which means it would block the subroute handler. In the second iteration (if no subroute routes match) blocking is the correct behaviour.
-			if i != 0 || cx.buf == nil || len(cx.buf[cx.offset:]) == 0 {
-				err = cx.prefetch()
-				if err != nil {
-					logFunc := logger.Error
-					if errors.Is(err, os.ErrDeadlineExceeded) {
-						err = ErrMatchingTimeout
-						logFunc = logger.Warn
-					}
-					logFunc("matching connection", zap.String("remote", cx.RemoteAddr().String()), zap.Error(err))
-					return nil // return nil so the error does not get logged again
+		for {
+			err = cx.prefetch()
+			if err != nil {
+				logFunc := logger.Error
+				if errors.Is(err, os.ErrDeadlineExceeded) {
+					err = ErrMatchingTimeout
+					logFunc = logger.Warn
 				}
+				logFunc("matching connection", zap.String("remote", cx.RemoteAddr().String()), zap.Error(err))
+				return nil // return nil so the error does not get logged again
 			}
 
 			for i, route := range routes {
-				// After a match continue with the routes after the matched one, instead of starting at the beginning.
-				// This is done for backwards compatibility with configs written before the "Non blocking matchers & matching timeout" rewrite.
-				// See https://github.com/mholt/caddy-l4/pull/192 and https://github.com/mholt/caddy-l4/pull/192#issuecomment-2143681952.
 				if i <= lastMatchedRouteIdx {
 					continue
 				}
-				// Only skip once after a match, so it behaves like we continued after the match.
-				lastMatchedRouteIdx = -1
+
+				// If the route is definitely not matched, skip it
+				if s, ok := routesStatus[i]; ok && s == routeNotMatched {
+					continue
+				}
+				// now the matcher is after a matched route and current route needs more data to determine if more data is needed.
+				// note a matcher is skipped if the one after it can determine it is matched
 
 				// A route must match at least one of the matcher sets
 				matched, err := route.matcherSets.AnyMatch(cx)
 				if errors.Is(err, ErrConsumedAllPrefetchedBytes) {
+					routesStatus[i] = routeNeedsMore
 					continue // ignore and try next route
 				}
 				if err != nil {
@@ -147,6 +157,8 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 					return nil
 				}
 				if matched {
+					routesStatus[i] = routeMatched
+					lastMatchedRouteIdx = i
 					// remove deadline after we matched
 					err = cx.Conn.SetReadDeadline(time.Time{})
 					if err != nil {
@@ -163,7 +175,7 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 						return nil
 					})
 					// compile the route handler stack with lastHandler being called last
-					handler := wrapHandler(next)(lastHandler)
+					handler := wrapHandler(forwardNextHandler{})(lastHandler)
 					for i := len(route.middleware) - 1; i >= 0; i-- {
 						handler = route.middleware[i](handler)
 					}
@@ -173,18 +185,30 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 					}
 
 					// If handler is terminal we stop routing,
-					// otherwise we jump back to the start of the routing loop to peel of more protocol layers.
+					// otherwise we try the next handler.
 					if isTerminal {
 						return nil
-					} else {
-						lastMatchedRouteIdx = i
-						goto router
 					}
+				} else {
+					routesStatus[i] = routeNotMatched
 				}
 			}
+			// end of match
+			if lastMatchedRouteIdx == len(routes)-1 {
+				// next is called because if the last handler is terminal, it's already returned
+				return next.Handle(cx)
+			}
+			var indetermined int
+			for i, s := range routesStatus {
+				if i > lastMatchedRouteIdx && s == routeNeedsMore {
+					indetermined++
+				}
+			}
+			// some of the matchers can't reach a conclusion
+			if indetermined > 0 {
+				goto loop
+			}
+			return next.Handle(cx)
 		}
-
-		logger.Error("matching connection", zap.String("remote", cx.RemoteAddr().String()), zap.Error(errors.New("number of prefetch calls exhausted")))
-		return nil
 	})
 }

--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -125,9 +125,9 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 			return err
 		}
 		for {
-			// only read more because there is no buffered data or matchers require more.
+			// only read more because matchers require more (no matcher in the simplest case).
 			// can happen if this routes list is embedded in another
-			if len(cx.buf) == 0 || matcherNeedMore {
+			if matcherNeedMore {
 				err = cx.prefetch()
 				if err != nil {
 					logFunc := logger.Error

--- a/layer4/routes_test.go
+++ b/layer4/routes_test.go
@@ -27,9 +27,9 @@ func TestMatchingTimeoutWorks(t *testing.T) {
 	matched := false
 	loggerCore, logs := observer.New(zapcore.WarnLevel)
 	compiledRoutes := routes.Compile(zap.New(loggerCore), 5*time.Millisecond,
-		NextHandlerFunc(func(con *Connection, next Handler) error {
+		HandlerFunc(func(con *Connection) error {
 			matched = true
-			return next.Handle(con)
+			return nil
 		}))
 
 	in, out := net.Pipe()

--- a/layer4/routes_test.go
+++ b/layer4/routes_test.go
@@ -2,7 +2,10 @@ package layer4
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -13,11 +16,33 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+type testIoMatcher struct {
+}
+
+func (testIoMatcher) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.matchers.testIoMatcher",
+		New: func() caddy.Module { return new(testIoMatcher) },
+	}
+}
+
+func (m *testIoMatcher) Match(cx *Connection) (bool, error) {
+	buf := make([]byte, 1)
+	n, err := io.ReadFull(cx, buf)
+	return n > 0, err
+}
+
 func TestMatchingTimeoutWorks(t *testing.T) {
 	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
 	defer cancel()
 
-	routes := RouteList{&Route{}}
+	caddy.RegisterModule(testIoMatcher{})
+
+	routes := RouteList{&Route{
+		MatcherSetsRaw: caddyhttp.RawMatcherSets{
+			caddy.ModuleMap{"testIoMatcher": json.RawMessage("{}")}, // any io using matcher
+		},
+	}}
 
 	err := routes.Provision(ctx)
 	if err != nil {

--- a/layer4/server.go
+++ b/layer4/server.go
@@ -68,7 +68,7 @@ func (s *Server) Provision(ctx caddy.Context, logger *zap.Logger) error {
 	if err != nil {
 		return err
 	}
-	s.compiledRoute = s.Routes.Compile(s.logger, time.Duration(s.MatchingTimeout), nopNextHandler{})
+	s.compiledRoute = s.Routes.Compile(s.logger, time.Duration(s.MatchingTimeout), nopHandler{})
 
 	return nil
 }

--- a/modules/l4http/httpmatcher_test.go
+++ b/modules/l4http/httpmatcher_test.go
@@ -314,7 +314,7 @@ func TestMatchHTTP_isHttp(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			matched := (&MatchHTTP{}).isHttp(tc.data)
+			_, matched := MatchHTTP{}.isHttp(tc.data)
 			if matched != tc.shouldMatch {
 				t.Fatalf("test %v | matched: %v != shouldMatch: %v", tc.name, matched, tc.shouldMatch)
 			}

--- a/modules/l4ssh/matcher.go
+++ b/modules/l4ssh/matcher.go
@@ -42,9 +42,9 @@ func (*MatchSSH) CaddyModule() caddy.ModuleInfo {
 // Match returns true if the connection looks like SSH.
 func (m *MatchSSH) Match(cx *layer4.Connection) (bool, error) {
 	p := make([]byte, len(sshPrefix))
-	n, err := io.ReadFull(cx, p)
-	if err != nil || n < len(sshPrefix) {
-		return false, nil
+	_, err := io.ReadFull(cx, p)
+	if err != nil {
+		return false, err
 	}
 	return bytes.Equal(p, sshPrefix), nil
 }

--- a/modules/l4subroute/handler.go
+++ b/modules/l4subroute/handler.go
@@ -70,10 +70,7 @@ func (h *Handler) Provision(ctx caddy.Context) error {
 
 // Handle handles the connections.
 func (h *Handler) Handle(cx *layer4.Connection, next layer4.Handler) error {
-	subroute := h.Routes.Compile(h.logger, time.Duration(h.MatchingTimeout),
-		layer4.NextHandlerFunc(func(cx *layer4.Connection, _ layer4.Handler) error {
-			return next.Handle(cx) // continue with original chain after subroute
-		}))
+	subroute := h.Routes.Compile(h.logger, time.Duration(h.MatchingTimeout), next)
 	return subroute.Handle(cx)
 }
 

--- a/modules/l4xmpp/matcher.go
+++ b/modules/l4xmpp/matcher.go
@@ -42,9 +42,9 @@ func (*MatchXMPP) CaddyModule() caddy.ModuleInfo {
 // Match returns true if the connection looks like XMPP.
 func (m *MatchXMPP) Match(cx *layer4.Connection) (bool, error) {
 	p := make([]byte, minXmppLength)
-	n, err := io.ReadFull(cx, p)
-	if err != nil || n < minXmppLength { // needs at least 50 (fix for adium/pidgin)
-		return false, nil
+	_, err := io.ReadFull(cx, p)
+	if err != nil { // needs at least 50 (fix for adium/pidgin)
+		return false, err
 	}
 	return strings.Contains(string(p), xmppWord), nil
 }


### PR DESCRIPTION
…ler behavior

The new non-blocking matcher breaks several things. Some of which can be avoided.

1. [No fallback handler](https://github.com/mholt/caddy-l4/issues/207): caused by breaking change that handler is only called for matched routes, and potentially several times due to the loop.
2. [Endless loop](https://github.com/mholt/caddy-l4/pull/199): caused by routes not realizing the handler is matched and called and still tries to read more data and loop.

The behavior will cause unnecessary read and loop as some of the matchers already make their conclusion about the status of the match. These matches will be skipped to avoid the loop.

The fallback handler is called correctly as before.