### PR TITLE
Rename ip handler into remote_ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Current matchers:
 - **layer4.matchers.tls** - matches connections that start with TLS handshakes. In addition, any [`tls.handshake_match` modules](https://caddyserver.com/docs/modules/) can be used for matching on TLS-specific properties of the ClientHello, such as ServerName (SNI).
 - **layer4.matchers.ssh** - matches connections that look like SSH connections.
 - **layer4.matchers.postgres** - matches connections that look like Postgres connections.
-- **layer4.matchers.ip** - matches connections based on remote IP (or CIDR range).
+- **layer4.matchers.remote_ip** - matches connections based on remote IP (or CIDR range).
 - **layer4.matchers.local_ip** - matches connections based on local IP (or CIDR range).
 - **layer4.matchers.proxy_protocol** - matches connections that start with [HAPROXY proxy protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt).
 - **layer4.matchers.socks4** - matches connections that look like [SOCKSv4](https://www.openssh.com/txt/socks4.protocol).
@@ -367,7 +367,7 @@ While only allowing connections from a specific network and requiring a username
 							"match": [
 								{
 									"socks5": {},
-									"ip": {"ranges": ["10.0.0.0/24"]}
+									"remote_ip": {"ranges": ["10.0.0.0/24"]}
 								}
 							],
 							"handle": [

--- a/layer4/matchers_test.go
+++ b/layer4/matchers_test.go
@@ -74,7 +74,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"127.0.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"127.0.0.1"}}),
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"127.0.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"127.0.0.1"}}),
 					},
 				},
 			},
@@ -110,7 +110,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"172.16.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"172.16.0.1"}}),
 					},
 					{
 						provision(&MatchLocalIP{Ranges: []string{"127.0.0.1"}}),
@@ -131,7 +131,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"172.16.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"172.16.0.1"}}),
 					},
 					{
 						provision(&MatchLocalIP{Ranges: []string{"127.0.0.1"}}),
@@ -152,7 +152,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"172.16.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"172.16.0.1"}}),
 					},
 					{
 						provision(&MatchLocalIP{Ranges: []string{"127.0.0.1"}}),
@@ -173,7 +173,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"172.16.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"172.16.0.1"}}),
 						provision(&MatchLocalIP{Ranges: []string{"127.0.0.1"}}),
 					},
 				},
@@ -192,7 +192,7 @@ func TestNotMatcher(t *testing.T) {
 			matcher: MatchNot{
 				MatcherSets: []MatcherSet{
 					{
-						provision(&MatchIP{Ranges: []string{"172.16.0.1"}}),
+						provision(&MatchRemoteIP{Ranges: []string{"172.16.0.1"}}),
 						provision(&MatchLocalIP{Ranges: []string{"127.0.0.1"}}),
 					},
 				},


### PR DESCRIPTION
As discussed in mholt/caddy-l4#217, this is a breaking change that renames `ip` handler into `remote_ip`. 

Consequently, we will have consistently named  `remote_ip` matchers at layer4, tls and http levels.

If this PR gets merged first, I will rebase mholt/caddy-l4#217 on it. Otherwise this PR will have to be rebased.