### PR TITLE
Disable dependencies updates of gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  # Maintain dependencies for Go modules
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -83,6 +83,7 @@ jobs:
         # TODO:
         # github.com/mholt/caddy-l4,
         # modules/l4echo,
+        # modules/l4postgres,
         # modules/l4ssh,
         # modules/l4subroute,
         # modules/l4tee,


### PR DESCRIPTION
@mohammed90 has mad it clear in this comment https://github.com/mholt/caddy-l4/pull/185#discussion_r1576269100

Instead of updating the dependencies here, we should do it on the upstream ( https://github.com/caddyserver/caddy ), and users are encouraged to keep their caddy up-to-date