### PR TITLE
Clock matcher: fix tests in non-UTC timezones

### DIFF
--- a/modules/l4clock/matcher_test.go
+++ b/modules/l4clock/matcher_test.go
@@ -41,8 +41,8 @@ func Test_MatchClock_Match(t *testing.T) {
 		shouldMatch bool
 	}
 
-	tNowMinus5Minutes := time.Now().Add(time.Minute * 5 * (-1)).Format(time.TimeOnly)
-	tNowPlus5Minutes := time.Now().Add(time.Minute * 5).Format(time.TimeOnly)
+	tNowMinus5Minutes := time.Now().UTC().Add(time.Minute * 5 * (-1)).Format(time.TimeOnly)
+	tNowPlus5Minutes := time.Now().UTC().Add(time.Minute * 5).Format(time.TimeOnly)
 
 	tests := []test{
 		{matcher: &MatchClock{}, data: []byte{}, shouldMatch: true},


### PR DESCRIPTION
I've found that I missed the UTC part in the tests while making the final adjustments to #225.

With these minor changes, the clock matcher tests won't fail in non-UTC timezones.