### PR TITLE
Fix a regression in #223: sanitise selected closures

### DIFF
--- a/layer4/app.go
+++ b/layer4/app.go
@@ -76,11 +76,15 @@ func (a *App) Start() error {
 				case net.Listener:
 					a.listeners = append(a.listeners, ln)
 					lnAddr = caddy.JoinNetworkAddress(ln.Addr().Network(), ln.Addr().String(), "")
-					go func() { _ = s.serve(ln) }()
+					go func(s *Server, ln net.Listener) {
+						_ = s.serve(ln)
+					}(s, ln)
 				case net.PacketConn:
 					a.packetConns = append(a.packetConns, ln)
 					lnAddr = caddy.JoinNetworkAddress(ln.LocalAddr().Network(), ln.LocalAddr().String(), "")
-					go func() { _ = s.servePacket(ln) }()
+					go func(s *Server, pc net.PacketConn) {
+						_ = s.servePacket(pc)
+					}(s, ln)
 				}
 				s.logger.Debug("listening", zap.String("address", lnAddr))
 			}


### PR DESCRIPTION
I've tracked the regression in https://github.com/mholt/caddy-l4/commit/ff5d9838277b1be085cc6f1ea578befbf764435b  to at least 2 rows of the code https://github.com/mholt/caddy-l4/commit/ff5d9838277b1be085cc6f1ea578befbf764435b#diff-ba204f43657cfc2b9fd32beb6baad78efc8ca53ff8dfe9ad4eb748f8f9395e36R79 and https://github.com/mholt/caddy-l4/commit/ff5d9838277b1be085cc6f1ea578befbf764435b#diff-ba204f43657cfc2b9fd32beb6baad78efc8ca53ff8dfe9ad4eb748f8f9395e36R83.

This PR sanitises all the closures added in https://github.com/mholt/caddy-l4/pull/223 and resolves the hanging connections bug.

I believe it will also resolve the problem reported by @lxhao61 in https://github.com/mholt/caddy-l4/commit/ff5d9838277b1be085cc6f1ea578befbf764435b#comments.