### PR TITLE
Adjust matchers after #208: return reading errors

### DIFF
--- a/modules/l4dns/matcher.go
+++ b/modules/l4dns/matcher.go
@@ -85,7 +85,7 @@ func (m *MatchDNS) Match(cx *layer4.Connection) (bool, error) {
 		msgBuf = make([]byte, msgBytes)
 		_, err = io.ReadFull(cx, msgBuf)
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 
 		// Validate the remaining connection buffer
@@ -101,7 +101,7 @@ func (m *MatchDNS) Match(cx *layer4.Connection) (bool, error) {
 		msgBuf = make([]byte, dnsHeaderBytes)
 		n, err := io.ReadAtLeast(cx, msgBuf, int(dnsHeaderBytes))
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 
 		// Read the remaining bytes and validate their length

--- a/modules/l4dns/matcher_test.go
+++ b/modules/l4dns/matcher_test.go
@@ -16,6 +16,7 @@ package l4dns
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -28,7 +29,7 @@ import (
 
 func assertNoError(t *testing.T, err error) {
 	t.Helper()
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("Unexpected error: %s\n", err)
 	}
 }

--- a/modules/l4rdp/matcher.go
+++ b/modules/l4rdp/matcher.go
@@ -71,7 +71,7 @@ func (m *MatchRDP) Match(cx *layer4.Connection) (bool, error) {
 	headerBuf := make([]byte, RDPConnReqBytesMin)
 	n, err := io.ReadFull(cx, headerBuf)
 	if err != nil || n < int(RDPConnReqBytesMin) {
-		return false, nil
+		return false, err
 	}
 
 	// Parse TPKTHeader
@@ -112,7 +112,7 @@ func (m *MatchRDP) Match(cx *layer4.Connection) (bool, error) {
 	payloadBuf := make([]byte, payloadBytesTotal)
 	n, err = io.ReadFull(cx, payloadBuf)
 	if err != nil || n < int(payloadBytesTotal) {
-		return false, nil
+		return false, err
 	}
 
 	// Validate the remaining connection buffer
@@ -121,7 +121,7 @@ func (m *MatchRDP) Match(cx *layer4.Connection) (bool, error) {
 	extraBuf := make([]byte, 1)
 	n, err = io.ReadFull(cx, extraBuf)
 	if err == nil && n == len(extraBuf) {
-		return false, nil
+		return false, err
 	}
 
 	// Find CRLF which divides token/cookie from RDPNegReq and RDPCorrInfo

--- a/modules/l4rdp/matcher_test.go
+++ b/modules/l4rdp/matcher_test.go
@@ -17,6 +17,7 @@ package l4rdp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -29,7 +30,7 @@ import (
 
 func assertNoError(t *testing.T, err error) {
 	t.Helper()
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("Unexpected error: %s\n", err)
 	}
 }

--- a/modules/l4regexp/matcher.go
+++ b/modules/l4regexp/matcher.go
@@ -50,7 +50,7 @@ func (m *MatchRegexp) Match(cx *layer4.Connection) (bool, error) {
 	buf := make([]byte, m.Count)
 	n, err := io.ReadFull(cx, buf)
 	if err != nil || n < int(m.Count) {
-		return false, nil
+		return false, err
 	}
 
 	// Match these bytes against the regular expression

--- a/modules/l4regexp/matcher_test.go
+++ b/modules/l4regexp/matcher_test.go
@@ -16,18 +16,20 @@ package l4regexp
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
 	"testing"
 
 	"github.com/caddyserver/caddy/v2"
-	"github.com/mholt/caddy-l4/layer4"
 	"go.uber.org/zap"
+
+	"github.com/mholt/caddy-l4/layer4"
 )
 
 func assertNoError(t *testing.T, err error) {
 	t.Helper()
-	if err != nil {
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Fatalf("Unexpected error: %s\n", err)
 	}
 }


### PR DESCRIPTION
This is a fix adjusting selected matchers to return reading errors so that the matching loop could continue after #208.