### PR TITLE
prefetch immediately if matchers requires more data and if not alread…

### DIFF
--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -157,6 +157,10 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 				if errors.Is(err, ErrConsumedAllPrefetchedBytes) {
 					lastNeedsMoreIdx = i
 					routesStatus[i] = routeNeedsMore
+					// the first time a matcher requires more data, exit the loop to force a prefetch
+					if !matcherNeedMore {
+						break
+					}
 					continue // ignore and try next route
 				}
 				if err != nil {


### PR DESCRIPTION
…y prefecthed

Fix some regressions introduced by [e491c44](https://github.com/mholt/caddy-l4/commit/e491c44895fe3f11e24ad4d8c4f6a668144c0ef9). That is caddy-l4 prioritized routes without any matchers defined. This patch will force some data to be read from the connection if a matcher needs more data for the first time in the matching process.