### PR TITLE
Mitigate TLS matching issues on FreeBSD when X25519Kyber768Draft00 is involved

### DIFF
--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -137,6 +137,11 @@ func (cx *Connection) Wrap(conn net.Conn) *Connection {
 func (cx *Connection) prefetch() (err error) {
 	var n int
 
+        // TODO: FreeBSD will not match TLS with X25519Kyber768Draft00 based TLS ClientHello.
+        // Adding a short sleep here mitigates this behavior and makes TLS match.
+        // This needs a proper solution in the future.
+        time.Sleep(1 * time.Millisecond)
+
 	// read once
 	if len(cx.buf) < MaxMatchingBytes {
 		free := cap(cx.buf) - len(cx.buf)


### PR DESCRIPTION
Mitigates this issue I have: https://github.com/mholt/caddy-l4/issues/250

Just wanted to offer it as workaround until there might be a better solution.

Additional discussion:

https://github.com/mholt/caddy-l4/pull/248#issuecomment-2392421915