### PR TITLE
Fix a regression in #224: the context may have no replacer

### DIFF
--- a/modules/l4tls/alpn_matcher.go
+++ b/modules/l4tls/alpn_matcher.go
@@ -37,7 +37,14 @@ func (*MatchALPN) CaddyModule() caddy.ModuleInfo {
 }
 
 func (m *MatchALPN) Match(hello *tls.ClientHelloInfo) bool {
-	repl := hello.Context().Value(caddy.ReplacerCtxKey).(*caddy.Replacer)
+	repl := caddy.NewReplacer()
+	if ctx := hello.Context(); ctx != nil {
+		// In some situations the existing context may have no replacer
+		if replAny := ctx.Value(caddy.ReplacerCtxKey); replAny != nil {
+			repl = replAny.(*caddy.Replacer)
+		}
+	}
+
 	clientProtocols := hello.SupportedProtos
 	for _, alpn := range *m {
 		alpn = repl.ReplaceAll(alpn, "")


### PR DESCRIPTION
This PR fixes the panics caused by the `tls alpn` matcher as reported in #259. The fix is a copy of https://github.com/caddyserver/caddy/commit/7cf8376e638948490be3e9eb5c7d58ce2a4b93b3 we merged into the mainline for the `tls sni` matcher a few month ago.