### PR TITLE
layer4: Export the context for tls sni_regexp matcher

### DIFF
--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -78,6 +78,12 @@ type Connection struct {
 var ErrConsumedAllPrefetchedBytes = errors.New("consumed all prefetched bytes")
 var ErrMatchingBufferFull = errors.New("matching buffer is full")
 
+// GetContext returns cx.Context,
+// so that caddytls.MatchServerNameRE.Match() could obtain this context without importing layer4.
+func (cx *Connection) GetContext() context.Context {
+	return cx.Context
+}
+
 // Read implements io.Reader in such a way that reads first
 // deplete any associated buffer from the prior recording,
 // and once depleted (or if there isn't one), it continues


### PR DESCRIPTION
This PR is the layer4 part of the fix described [here](https://github.com/mholt/caddy-l4/issues/241#issuecomment-2610292874) for the issue with missing `{tls.regexp.*}` placeholders reported [here](https://github.com/mholt/caddy-l4/issues/241#issuecomment-2609215818).