### PR TITLE
l4quic: Close quic.EarlyListener only if it has accepted a new connection

### DIFF
--- a/modules/l4quic/matcher.go
+++ b/modules/l4quic/matcher.go
@@ -130,7 +130,6 @@ func (m *MatchQUIC) Match(cx *layer4.Connection) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer func() { _ = qListener.Close() }()
 
 	// Write the buffered bytes into the pipe
 	n, err = clientFPC.WriteTo(buf[:n+1], nil)
@@ -148,6 +147,7 @@ func (m *MatchQUIC) Match(cx *layer4.Connection) (bool, error) {
 	if err != nil {
 		return false, nil
 	}
+	defer func() { _ = qListener.Close() }()
 
 	// Obtain a quic.ConnectionState
 	qState := qConn.ConnectionState()


### PR DESCRIPTION
This change fixes a bug and is required before we upgrade dependencies to `go` v.1.24, `caddyserver/caddy` v2.10.0 and `quic-go` v0.51.0. See also https://github.com/mholt/caddy-l4/pull/312#issuecomment-3160302145.