### PR TITLE
fix route matching behavior when more data is needed

### DIFF
--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -112,8 +112,7 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 		var (
 			lastMatchedRouteIdx = -1
 			// it actually records where a matcher may require more data, i.e. the one that really needs more,
-			// it actually records where a matcher may require more data, i.e. the one that really needs more,
-			// the one after a matched route, the one after a not matched route with no previous routes needing more
+			// the one after a matched route, the one after a not matched route with no previous routes needing more.
 			// -1 means there is no route that requires more data
 			lastNeedsMoreIdx = -1
 			routesStatus     = make(map[int]int)
@@ -211,7 +210,7 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 						return nil
 					}
 				} else {
-					// update the last index to search for unmatched matchers
+					// update the last index to search for unmatched matchers.
 					if i >= lastNeedsMoreIdx {
 						lastNeedsMoreIdx = i + 1
 					}


### PR DESCRIPTION
Current route matching is kind of buggy when a route that matches everything is chosen, the condition to check is wrong. Instead of checking if there is anything route before current one that needs more data, the comparison is with if any of the routes needs more.

Now the check is to see if any route before the current one needs more. Also updated the logic behind updating the last index where a route requires more data.

Fix #356 