### PR TITLE
Implement close handler

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -31,7 +31,8 @@ Handlers are categorized into different types based on their relationship with n
 
 | Type                  | Handler                                                | Implements                                                                                      |
 |:----------------------|:-------------------------------------------------------|:------------------------------------------------------------------------------------------------|
-| Terminal handlers     | [**echo**](/docs/handlers/echo.md)                     | Echo server, i.e. sends back exactly what it receives                                           |
+| Terminal handlers     | [**close**](/docs/handlers/close.md)                   | Closing action for connection-oriented protocols, e.g. TCP                                      |
+|                       | [**echo**](/docs/handlers/echo.md)                     | Echo server, i.e. sends back exactly what it receives                                           |
 |                       | [**proxy**](/docs/handlers/proxy.md)                   | Layer 4 proxy, capable of multiple upstreams (with load balancing and health checks)            |
 |                       | [**socks5**](/docs/handlers/socks5.md)                 | [SOCKSv5](https://www.rfc-editor.org/rfc/rfc1928) server                                        |
 | Intermediary handlers | [**proxy_protocol**](/docs/handlers/proxy_protocol.md) | Receiving [HAProxy Proxy Protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) |

--- a/docs/handlers/close.md
+++ b/docs/handlers/close.md
@@ -1,0 +1,62 @@
+---
+title: Close Handler
+---
+
+# Close Handler
+
+## Summary
+
+The Close handler close connections. Note that it's relevant to connection-oriented protocols (e.g. TCP)
+and irrelevant to connectionless protocols (e.g. UDP).
+
+## Syntax
+
+The handler has no fields and supports no [placeholders](https://caddyserver.com/docs/conventions#placeholders).
+
+### Caddyfile
+
+The handler supports the following syntax:
+```caddyfile
+close
+```
+
+An example config of the Layer 4 app that closes any incoming connections on TCP4 port 8888:
+```caddyfile
+{
+    layer4 {
+        0.0.0.0:8888 {
+            route {
+                close
+            }
+        }
+    }
+}
+```
+
+### JSON
+
+JSON equivalent to the caddyfile config provided above:
+```json
+{
+    "apps": {
+        "layer4": {
+            "servers": {
+                "srv0": {
+                    "listen": [
+                        "0.0.0.0:8888"
+                    ],
+                    "routes": [
+                        {
+                            "handle": [
+                                {
+                                    "handler": "close"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+```

--- a/imports.go
+++ b/imports.go
@@ -18,6 +18,7 @@ import (
 	// plugging in the standard modules for the layer4 app
 	_ "github.com/mholt/caddy-l4/layer4"
 	_ "github.com/mholt/caddy-l4/modules/l4clock"
+	_ "github.com/mholt/caddy-l4/modules/l4close"
 	_ "github.com/mholt/caddy-l4/modules/l4dns"
 	_ "github.com/mholt/caddy-l4/modules/l4echo"
 	_ "github.com/mholt/caddy-l4/modules/l4http"

--- a/integration/caddyfile_adapt/gd_handler_close.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_close.caddytest
@@ -1,0 +1,32 @@
+{
+	layer4 {
+		0.0.0.0:8888 {
+			route {
+				close
+			}
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"layer4": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						"0.0.0.0:8888"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "close"
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/l4close/close.go
+++ b/modules/l4close/close.go
@@ -1,0 +1,53 @@
+package l4close
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+
+	"github.com/mholt/caddy-l4/layer4"
+)
+
+func init() {
+	caddy.RegisterModule(&HandleClose{})
+}
+
+// HandleClose is able to close connections.
+type HandleClose struct{}
+
+// CaddyModule returns the Caddy module information.
+func (*HandleClose) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.handlers.close",
+		New: func() caddy.Module { return new(HandleClose) },
+	}
+}
+
+// Handle handles the connection.
+func (h *HandleClose) Handle(cx *layer4.Connection, _ layer4.Handler) error {
+	return cx.Close()
+}
+
+// UnmarshalCaddyfile sets up the HandleClose from Caddyfile tokens. Syntax:
+//
+//	close
+func (h *HandleClose) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	_, wrapper := d.Next(), d.Val() // consume wrapper name
+
+	// No same-line options are supported
+	if d.CountRemainingArgs() > 0 {
+		return d.ArgErr()
+	}
+
+	// No blocks are supported
+	if d.NextBlock(d.Nesting()) {
+		return d.Errf("malformed layer4 connection handler '%s': blocks are not supported", wrapper)
+	}
+
+	return nil
+}
+
+// Interface guards
+var (
+	_ caddyfile.Unmarshaler = (*HandleClose)(nil)
+	_ layer4.NextHandler    = (*HandleClose)(nil)
+)


### PR DESCRIPTION
This PR implements `close` handler as requested in #371. As mentioned in the docs, the handler is relevant to connection-oriented protocols (e.g. TCP) and irrelevant to connectionless protocols (e.g. UDP).

I haven't tested this handler yet, so please report whether it works correctly for you with TCP and doesn't break UDP.