### PR TITLE
proxy: Treat TLS server names carefully

### DIFF
--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -249,8 +249,15 @@ func (h *Handler) dialPeers(upstream *Upstream, repl *caddy.Replacer, down *laye
 					tlsCfg.NextProtos = []string{nextProto}
 				}
 			}
-			// Expand any placeholders in the upstream server name before dialing it
-			tlsCfg.ServerName = repl.ReplaceAll(tlsCfg.ServerName, "")
+			// Expand any placeholders in the upstream server name before dialing it;
+			// since the same upstream TLS config is reused for subsequent connections,
+			// we have to clone it if any placeholders in ServerName are expanded
+			valServerName := repl.ReplaceAll(tlsCfg.ServerName, "")
+			if valServerName != tlsCfg.ServerName {
+				newTLSCfg := tlsCfg.Clone()
+				newTLSCfg.ServerName = valServerName
+				tlsCfg = newTLSCfg
+			}
 			up, err = tls.Dial(p.address.Network, hostPort, tlsCfg)
 		}
 		h.logger.Debug("dial upstream",

--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -228,22 +228,28 @@ func (h *Handler) dialPeers(upstream *Upstream, repl *caddy.Replacer, down *laye
 		if upstream.TLS == nil {
 			up, err = net.Dial(p.address.Network, hostPort)
 		} else {
-			// the prepared config could be nil if user enabled but did not customize TLS,
-			// but in any case we adopt the downstream client's TLS ClientHello for ours;
-			// i.e. by default, make the client's TLS config as transparent as possible
+			// The prepared config could be nil, if the user enabled but did not customize TLS
 			tlsCfg := upstream.tlsConfig
 			if tlsCfg == nil {
 				tlsCfg = new(tls.Config)
 			}
+			// In any case we adopt the downstream client's TLS ClientHello for the upstream;
+			// i.e. by default, make the client's TLS config as transparent as possible,
+			// except for the server name which is automatically set to the upstream hostname
+			// unless the user explicitly configured it to have a different value
 			if hellos := l4tls.GetClientHelloInfos(down); len(hellos) > 0 {
 				hellos[0].FillTLSClientConfig(tlsCfg)
 			}
+			// If there is a downstream TLS connection and a non-empty negotiated protocol,
+			// the upstream TLS config should have it as the only supported protocol
+			// TODO: Make the upstream application-layer protocol customizable
 			if connStates := l4tls.GetConnectionStates(down); len(connStates) > 0 {
 				nextProto := connStates[0].NegotiatedProtocol
 				if len(nextProto) > 0 {
 					tlsCfg.NextProtos = []string{nextProto}
 				}
 			}
+			// Expand any placeholders in the upstream server name before dialing it
 			tlsCfg.ServerName = repl.ReplaceAll(tlsCfg.ServerName, "")
 			up, err = tls.Dial(p.address.Network, hostPort, tlsCfg)
 		}

--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -244,6 +244,7 @@ func (h *Handler) dialPeers(upstream *Upstream, repl *caddy.Replacer, down *laye
 					tlsCfg.NextProtos = []string{nextProto}
 				}
 			}
+			tlsCfg.ServerName = repl.ReplaceAll(tlsCfg.ServerName, "")
 			up, err = tls.Dial(p.address.Network, hostPort, tlsCfg)
 		}
 		h.logger.Debug("dial upstream",

--- a/modules/l4tls/clienthello.go
+++ b/modules/l4tls/clienthello.go
@@ -49,6 +49,17 @@ type ClientHelloInfo struct {
 // FillTLSClientConfig fills cfg (a client-side TLS config) with information
 // from chi. It does not overwrite any fields in cfg that are already non-zero.
 func (chi ClientHelloInfo) FillTLSClientConfig(cfg *tls.Config) {
+	// We do not assign cfg.ServerName to chi.ServerName here,
+	// because the upstream connection (cfg) shouldn't have
+	// the same server name as the downstream connection (chi),
+	// yet it might be the case. By default, the upstream
+	// connection will have an empty server name which sets it
+	// equal to the upstream hostname under the hood of crypto/tls.
+	// If cfg.ServerName contains placeholders, they will be expanded
+	// at match, so that `{l4.tls.server_name}` could make
+	// the upstream connection copy the downstream server name. See also:
+	// https://github.com/mholt/caddy-l4/issues/392#issuecomment-4061385214
+
 	if cfg.NextProtos == nil {
 		cfg.NextProtos = chi.SupportedProtos
 	}

--- a/modules/l4tls/clienthello.go
+++ b/modules/l4tls/clienthello.go
@@ -52,9 +52,6 @@ func (chi ClientHelloInfo) FillTLSClientConfig(cfg *tls.Config) {
 	if cfg.NextProtos == nil {
 		cfg.NextProtos = chi.SupportedProtos
 	}
-	if cfg.ServerName == "" {
-		cfg.ServerName = chi.ServerName
-	}
 	if cfg.CipherSuites == nil {
 		cfg.CipherSuites = chi.CipherSuites
 	}


### PR DESCRIPTION
This PR implements the TODOs mentioned in [this comment](https://github.com/mholt/caddy-l4/issues/392#issuecomment-4061385214) and fixes the bug of server names being copied from the downstream to the upstream after #393.