### PR TITLE
chore: No space between // and nolint

### DIFF
--- a/modules/l4openvpn/matcher.go
+++ b/modules/l4openvpn/matcher.go
@@ -144,7 +144,7 @@ type MatchOpenVPN struct {
 	// may be present in OpenVPN client config files inside `<tls-crypt-v2/>` block or generated with `openvpn
 	// --tls-crypt-v2 [server.key] --genkey tls-crypt-v2-client` command. No comments (starting with '#' or '-')
 	// are allowed.
-	ClientKeys []string `json:"client_keys,omitempty"` // nolint:gosec // disable G117
+	ClientKeys []string `json:"client_keys,omitempty"` //nolint:gosec // disable G117
 	// ClientKeyFiles is a list of paths to files containing 2048-bit client key which may be present in OpenVPN
 	// config files after `tls-crypt-v2` directive. These are the same keys as those ClientKeys introduce, but
 	// these fields are complementary. If both are set, a joint list of client keys is created. Any comments in

--- a/modules/l4rdp/matcher.go
+++ b/modules/l4rdp/matcher.go
@@ -782,7 +782,7 @@ const (
 		2 + // 2 bytes for CR LF
 		0
 	RDPTokenOptionalCookieBytesStart uint16 = 0
-	RDPTokenOptionalCookiePrefix            = "Cookie: msts=" // nolint:gosec // disable G101
+	RDPTokenOptionalCookiePrefix            = "Cookie: msts=" //nolint:gosec // disable G101
 	RDPTokenOptionalCookieReserved          = "0000"
 	RDPTokenOptionalCookieSeparator  uint8  = 0x2E
 

--- a/modules/l4tls/matcher.go
+++ b/modules/l4tls/matcher.go
@@ -88,7 +88,7 @@ func (m *MatchTLS) Match(cx *layer4.Connection) (bool, error) {
 	}
 
 	// get length of the ClientHello message and read it
-	// nolint:gosec // disable G602 // https://github.com/securego/gosec/issues/1406
+	//nolint:gosec // disable G602 // https://github.com/securego/gosec/issues/1406
 	length := int(uint16(hdr[3])<<8 | uint16(hdr[4])) // ignoring version in hdr[1:3] - like https://github.com/inetaf/tcpproxy/blob/master/sni.go#L170
 	rawHello := make([]byte, length)
 	_, err = io.ReadFull(cx, rawHello)
@@ -108,7 +108,7 @@ func (m *MatchTLS) Match(cx *layer4.Connection) (bool, error) {
 			break
 		}
 
-		// nolint:gosec // disable G602 // https://github.com/securego/gosec/issues/1406
+		//nolint:gosec // disable G602 // https://github.com/securego/gosec/issues/1406
 		length2 := int(uint16(hdr2[3])<<8 | uint16(hdr2[4]))
 		if len(rawHello)+length2 > layer4.MaxMatchingBytes {
 			return false, fmt.Errorf("TLS records too large: %d > %d", len(rawHello)+length2, layer4.MaxMatchingBytes)
@@ -143,7 +143,7 @@ func (m *MatchTLS) Match(cx *layer4.Connection) (bool, error) {
 				break
 			}
 
-			// nolint:gosec // disable G602 // https://github.com/securego/gosec/issues/1406
+			//nolint:gosec // disable G602 // https://github.com/securego/gosec/issues/1406
 			length2 := int(uint16(hdr2[3])<<8 | uint16(hdr2[4]))
 
 			if len(rawHello)+length2 > layer4.MaxMatchingBytes {


### PR DESCRIPTION
This PR removes extra spaces between `//` and `nolint` to comply with the [syntax guidelines](https://golangci-lint.run/docs/linters/false-positives/#syntax).

No AI was used.