### PR TITLE
l4quic: panic-recover the WaitForMore goroutine

### DIFF
--- a/modules/l4quic/matcher.go
+++ b/modules/l4quic/matcher.go
@@ -35,6 +35,7 @@ import (
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddytls"
 	"github.com/quic-go/quic-go"
+	"go.uber.org/zap"
 
 	"github.com/mholt/caddy-l4/layer4"
 	"github.com/mholt/caddy-l4/modules/l4tls"
@@ -180,14 +181,28 @@ func (m *MatchQUIC) Match(cx *layer4.Connection) (bool, error) {
 	// spawn a new go routine to monitor new data. It's possible the available data is enough to determine the quic connection and the context is wrongly canceled.
 	done := make(chan struct{})
 	go func() {
+		// close(done) lives in a deferred recovery so a future refactor
+		// that breaks the cx.isPacketConn invariant (or any other panic
+		// inside WaitForMore) cannot leave Match() blocked forever at
+		// the <-done wait below. Logs the panic + remote addr so
+		// operators can attribute the symptom.
+		defer func() {
+			if r := recover(); r != nil {
+				cx.Logger.Error("panic in quic matcher WaitForMore goroutine",
+					zap.String("network", cx.LocalAddr().Network()),
+					zap.String("local", cx.LocalAddr().String()),
+					zap.String("remote", cx.RemoteAddr().String()),
+					zap.Any("panic", r),
+				)
+			}
+			close(done)
+		}()
 		// during testing the connection is not a packet conn
 		if isTesting {
-			close(done)
 			return
 		}
 		_ = cx.WaitForMore(qContext)
 		qCancel()
-		close(done)
 	}()
 
 	// Accept a new quic.EarlyConnection


### PR DESCRIPTION
## Summary

If \`WaitForMore\` (or any code reachable from it via a future refactor that breaks the \`cx.isPacketConn\` invariant) panics, the goroutine's \`close(done)\` never runs and \`Match()\` blocks forever at the \`<-done\` wait below it.

## Fix

Wrap \`close(done)\` in a deferred panic recovery, and log the panic with the remote addr so operators can attribute the symptom.

Defensive only — no known panic source today; this is a robustness fix to prevent a future change in \`WaitForMore\` (or anything it calls into) from silently deadlocking the matcher in production.

## Test plan

- [x] \`go test ./modules/l4quic/\` passes (existing tests cover the success and timeout-by-deadline paths; the panic-recovery path can't be exercised without a synthetic panic injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)