### PR TITLE
l4quic: close qListener on every Match() exit path

### DIFF
--- a/modules/l4quic/matcher.go
+++ b/modules/l4quic/matcher.go
@@ -132,8 +132,6 @@ func (m *MatchQUIC) Match(cx *layer4.Connection) (bool, error) {
 
 	// Create a new fakePacketConn pipe
 	serverFPC, clientFPC := newFakePacketConnPipe(&fakePipeAddr{ID: newRand(), TS: time.Now()}, nil)
-	defer func() { _ = serverFPC.Close() }()
-	defer func() { _ = clientFPC.Close() }()
 
 	// Create a new quic.Transport
 	qTransport := quic.Transport{
@@ -144,8 +142,20 @@ func (m *MatchQUIC) Match(cx *layer4.Connection) (bool, error) {
 	var qListener *quic.EarlyListener
 	qListener, err = qTransport.ListenEarly(tlsConf, m.quicConf)
 	if err != nil {
+		_ = serverFPC.Close()
+		_ = clientFPC.Close()
 		return false, err
 	}
+	// Single combined cleanup so qListener.Close() always runs (closes the
+	// upstream-leaked listener on Accept-error paths) and the fakePacketConn
+	// pipes close BEFORE the listener — closing the listener triggers the
+	// QUIC server's connection-close goroutine to write a CLOSE frame, which
+	// would otherwise deadlock on an unread pipe in the Accept-timeout case.
+	defer func() {
+		_ = serverFPC.Close()
+		_ = clientFPC.Close()
+		_ = qListener.Close()
+	}()
 
 	// Write the buffered bytes into the pipe
 	_, err = clientFPC.WriteTo(buf[:n+1], nil)
@@ -189,7 +199,6 @@ func (m *MatchQUIC) Match(cx *layer4.Connection) (bool, error) {
 		// The only type of error here will be context.DeadlineExceeded and context.Canceled
 		return false, layer4.ErrConsumedAllPrefetchedBytes
 	}
-	defer func() { _ = qListener.Close() }()
 
 	// Obtain a quic.ConnectionState
 	qState := qConn.ConnectionState()


### PR DESCRIPTION
## Summary

\`MatchQUIC.Match()\` registers \`defer qListener.Close()\` only AFTER a successful \`Accept()\` ([\`matcher.go:192\`](https://github.com/mholt/caddy-l4/blob/master/modules/l4quic/matcher.go#L192)), which leaks the listener on every error path between \`ListenEarly\` and \`Accept\`, and on \`Accept\`'s own error path.

Under high churn — e.g. a busy edge node where most UDP traffic on the listener port is not QUIC handshakes, or a client that retransmits the QUIC Initial multiple times before giving up — this accumulates leaked listeners (and their underlying transports) quickly enough to surface as a real resource leak.

## Fix

Move cleanup into a single combined defer registered immediately after \`ListenEarly\` succeeds, so it runs on every Match() exit path past that point.

The naive "register \`defer qListener.Close()\` right after \`ListenEarly\`" approach deadlocks the existing test: closing \`qListener\` triggers the QUIC server's connection-close goroutine to send a CLOSE frame via \`serverFPC\`, which blocks on the unread internal pipe in the Accept-timeout path. The combined defer solves this by closing the \`fakePacketConn\` pipes **before** the listener — pipe-close errors out the pending CLOSE write so \`qListener.Close()\` can return.

\`ListenEarly\`'s own failure path closes the FPCs explicitly (the combined defer isn't yet registered, since we don't have a listener to close).

## Test plan

- [x] \`go test ./modules/l4quic/\` passes (the existing \`Test_MatchQUIC_Match\` exercises both Accept-success and Accept-timeout paths).

## Relation to mholt/caddy-l4#413, #414, #415

Independent. Lands cleanly with or without those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)