### PR TITLE
lint: Modernize reverse loops over slices

### DIFF
--- a/layer4/handlers.go
+++ b/layer4/handlers.go
@@ -14,6 +14,8 @@
 
 package layer4
 
+import "slices"
+
 // Handlers is a list of connection handlers.
 type Handlers []NextHandler
 
@@ -25,8 +27,8 @@ func (h Handlers) Compile() Handler {
 		midware = append(midware, wrapHandler(midhandler))
 	}
 	var next Handler = nopHandler{}
-	for i := len(midware) - 1; i >= 0; i-- {
-		next = midware[i](next)
+	for _, v := range slices.Backward(midware) {
+		next = v(next)
 	}
 	return next
 }

--- a/layer4/routes.go
+++ b/layer4/routes.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
@@ -196,8 +197,8 @@ func (routes RouteList) Compile(logger *zap.Logger, matchingTimeout time.Duratio
 					})
 					// compile the route handler stack with lastHandler being called last
 					handler := wrapHandler(forwardNextHandler{})(lastHandler)
-					for i := len(route.middleware) - 1; i >= 0; i-- {
-						handler = route.middleware[i](handler)
+					for _, v := range slices.Backward(route.middleware) {
+						handler = v(handler)
 					}
 					err = handler.Handle(cx)
 					if err != nil {


### PR DESCRIPTION
This PR fixes the following linter warnings:
```
layer4\handlers.go:28:6: slicesbackward: backward loop over slice can be modernized using slices.Backward (modernize)
        for i := len(midware) - 1; i >= 0; i-- {
            ^
layer4\routes.go:199:10: slicesbackward: backward loop over slice can be modernized using slices.Backward (modernize)
                                        for i := len(route.middleware) - 1; i >= 0; i-- {
                                            ^
2 issues:
* modernize: 2
```

No AI was involved.