### PR TITLE
fix(proxy_protocol): size go-proxyproto's bufio to MaxBufLen

### DIFF
--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -340,6 +340,19 @@ const prefetchChunkSize = 2048
 // 16 KiB should cover most use-cases and is similar to popular webservers.
 const MaxMatchingBytes = 16 * 1024
 
+// MaxBufLen is the strict upper bound on Connection.buf length after all
+// prefetch operations. prefetch() checks `len(cx.buf) < MaxMatchingBytes`
+// before reading, and a single read can append up to prefetchChunkSize
+// bytes on top — so cx.buf can end up at MaxMatchingBytes - 1 +
+// prefetchChunkSize bytes. Handlers that wrap cx in a buffered reader
+// (e.g. proxyproto.Conn via WithBufferSize) should size that buffer to at
+// least this value to guarantee a single Read drains cx.buf in one call,
+// firing cx.Read's reset branch and leaving cx.buf cleanly empty for the
+// wrapped chain. Sizing only to MaxMatchingBytes leaves a 2 KiB-wide
+// hole where cx.buf can outrun the wrapper's internal buffer and produce
+// a misaligned post-wrap byte stream.
+const MaxBufLen = MaxMatchingBytes + prefetchChunkSize
+
 var bufPool = sync.Pool{
 	New: func() any {
 		return make([]byte, 0, prefetchChunkSize)

--- a/modules/l4proxyprotocol/handler.go
+++ b/modules/l4proxyprotocol/handler.go
@@ -162,11 +162,37 @@ func (h *Handler) newConn(cx *layer4.Connection) *proxyproto.Conn {
 		return nil
 	}
 
-	// Create connection with timeout option
+	// Create connection with timeout option.
 	var opts []func(*proxyproto.Conn)
 	if h.Timeout > 0 {
 		opts = append(opts, proxyproto.SetReadHeaderTimeout(time.Duration(h.Timeout)))
 	}
+
+	// Size go-proxyproto's internal bufio.Reader to layer4.MaxBufLen, the
+	// strict upper bound on cx.buf after all prefetch operations
+	// (MaxMatchingBytes + one extra prefetchChunkSize, since prefetch()
+	// guards with `len < MaxMatchingBytes` *before* the read and can then
+	// append up to prefetchChunkSize bytes on top).
+	//
+	// The default bufio size in go-proxyproto is 256 bytes (readBufferSize
+	// in protocol.go), which causes a stream-alignment bug when cx.buf
+	// already holds a prefetched chunk larger than 256: bufio drains only
+	// 256 bytes from cx via cx.Read, advancing cx.offset to 256 without
+	// triggering the "offset == len(buf)" reset branch. The remaining
+	// prefetched bytes in cx.buf are then unreachable to the wrapped conn
+	// (proxyproto.Conn only knows about bufio's contents + future
+	// underlying reads), so subsequent matchers either see misaligned
+	// mid-stream data (when they read from cx.buf directly) or time out
+	// waiting for bytes that aren't coming (when they read through
+	// proxyproto.Conn, which only has bufio's leftover).
+	//
+	// By sizing bufio to MaxBufLen, the first cx.Read drains all of
+	// cx.buf in one call regardless of how many prefetch iterations
+	// preceded the handler, the reset branch fires, and bufio ends up
+	// holding the entire prefetched chunk minus the PROXY header. All
+	// post-header bytes then flow through proxyproto.Conn.Read in order,
+	// matching the stream the wrapped conn semantically represents.
+	opts = append(opts, proxyproto.WithBufferSize(layer4.MaxBufLen))
 
 	return proxyproto.NewConn(cx, opts...)
 }

--- a/modules/l4proxyprotocol/handler_test.go
+++ b/modules/l4proxyprotocol/handler_test.go
@@ -132,3 +132,258 @@ func TestProxyProtocolHandleGarbage(t *testing.T) {
 
 	_, _ = io.Copy(io.Discard, in)
 }
+
+// TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher is a
+// regression test for a buffer-alignment bug between caddy-l4's
+// prefetched matching buffer and pires/go-proxyproto's internal
+// bufio.Reader.
+//
+// In production, when the matching loop has already prefetched a large
+// chunk (e.g. PROXY v2 header + a 1.8 KB TLS ClientHello) into cx.buf
+// and the proxy_protocol matcher then matches, the handler invokes
+// proxyproto.NewConn(cx). go-proxyproto's default bufio.Reader is
+// hard-coded to 256 bytes (see go-proxyproto protocol.go: const
+// readBufferSize = 256). Its first fill issues one cx.Read for 256
+// bytes, advancing cx.offset to 256 but leaving cx.buf at its
+// prefetched length — because the cx.Read reset branch only fires
+// when offset == len(buf). After that:
+//   - cx.buf[0:256] has been consumed by bufio (28 bytes go to
+//     parseHeader; ~228 remain inside bufio's private buffer);
+//   - cx.buf[256:] is unread by anyone but still present in the slice.
+//
+// cx.Wrap then carries the now-misaligned cx.buf into the wrapped
+// connection, and subsequent matchers either read mid-stream junk out
+// of cx.buf[256:] (when matching=false reads bypass bufio) or run out
+// of bytes waiting for ones that won't arrive (when reads go through
+// bufio and the underlying conn is already drained). In production
+// the latter manifests as a 3-second ErrMatchingTimeout; in this test
+// the underlying net.Pipe is closed so the same condition surfaces as
+// io.ErrUnexpectedEOF.
+//
+// The fix is to size go-proxyproto's bufio.Reader to layer4.MaxBufLen
+// (= MaxMatchingBytes + prefetchChunkSize) via the WithBufferSize
+// option. That sizing strictly exceeds the upper bound on cx.buf, so
+// the first fill drains all of cx.buf in one cx.Read, triggering the
+// reset branch and leaving cx.buf empty while bufio holds the entire
+// post-PROXY-header byte stream. Subsequent reads through
+// proxyproto.Conn return TLS bytes in stream order.
+//
+// The test reads two regions: the 5-byte TLS record header (catches
+// the misalignment variant — hdr[0] would be 0xAA filler if reads
+// bypass bufio) and the full record body (catches the byte-loss
+// variant — ReadFull would EOF mid-body if cx.buf bytes were dropped
+// or made unreachable).
+func TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher(t *testing.T) {
+	payload := buildPROXYv2PlusFakeTLSPayload(1832)
+	assertProxyV2WithFakeTLSReadsCleanlyAfterHandler(t, payload)
+}
+
+// TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher_LargePrefetch
+// guards the failure mode the smaller test cannot reach: cx.buf can
+// grow past MaxMatchingBytes by up to one prefetchChunkSize, because
+// prefetch() gates with `len(cx.buf) < MaxMatchingBytes` before the
+// read rather than after. A bufio sized only to MaxMatchingBytes leaves
+// the same alignment bug active at the high end of cx.buf's range.
+// Sizing to MaxBufLen (= MaxMatchingBytes + prefetchChunkSize) is what
+// makes the fix's invariant hold strictly. Without the fix, hdr[0]
+// here would be mid-stream filler from cx.buf[MaxMatchingBytes:].
+func TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher_LargePrefetch(t *testing.T) {
+	// 17 KiB total = PROXY v2 (28 bytes) + a TLS-shaped record whose
+	// length pushes cx.buf past 16 KiB (= MaxMatchingBytes) into the
+	// prefetchChunkSize-wide hole the old sizing left open. The record
+	// body must be ≤ 2^14-1 (TLS spec), so we fragment via two
+	// back-to-back TLS records.
+	const totalBytes = 17 * 1024
+	payload := buildPROXYv2PlusTwoFakeTLSRecordsPayload(totalBytes)
+	if len(payload) != totalBytes {
+		t.Fatalf("payload builder produced %d bytes, want %d", len(payload), totalBytes)
+	}
+	assertProxyV2WithFakeTLSReadsCleanlyAfterHandler(t, payload)
+}
+
+// assertProxyV2WithFakeTLSReadsCleanlyAfterHandler runs payload (PROXY
+// v2 header + one or more TLS-shaped records) through the handler with
+// cx.buf pre-populated, then verifies the wrapped Connection serves the
+// post-header bytes in stream order — first 5 bytes are the TLS record
+// header, full record body is readable and starts with the ClientHello
+// handshake type 0x01. Used by both the small-payload and
+// large-payload regression tests above.
+func assertProxyV2WithFakeTLSReadsCleanlyAfterHandler(t *testing.T, payload []byte) {
+	t.Helper()
+
+	wg := &sync.WaitGroup{}
+	in, out := net.Pipe()
+	defer closePipe(wg, in, out)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Close immediately — the payload is delivered via cx.buf,
+		// not via Pipe reads. Any read on cx.Conn after bufio drains
+		// its leftover should EOF cleanly.
+		_ = out.Close()
+	}()
+
+	cx := layer4.WrapConnection(in, payload, zap.NewNop())
+
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	defer cancel()
+
+	handler := Handler{}
+	err := handler.Provision(ctx)
+	assertNoError(t, err)
+
+	var wrappedCx *layer4.Connection
+	err = handler.Handle(cx, layer4.HandlerFunc(func(c *layer4.Connection) error {
+		wrappedCx = c
+		return nil
+	}))
+	assertNoError(t, err)
+	if wrappedCx == nil {
+		t.Fatalf("handler did not call next")
+	}
+	assertString(t, "1.2.3.4:12345", wrappedCx.RemoteAddr().String())
+
+	// Read the 5-byte TLS record header — catches the misalignment
+	// variant (reads bypassing bufio land in cx.buf[256:]).
+	hdr := make([]byte, 5)
+	n, readErr := io.ReadFull(wrappedCx, hdr)
+	if readErr != nil {
+		t.Fatalf("ReadFull(5): n=%d err=%v", n, readErr)
+	}
+	if hdr[0] != 0x16 {
+		t.Fatalf("subsequent matcher would read non-TLS bytes after proxy_protocol "+
+			"handler: hdr=% x (want first byte 0x16). The handler is leaving a stale "+
+			"prefetched buffer behind; ensure proxyproto.NewConn is given "+
+			"WithBufferSize(layer4.MaxBufLen) so its bufio drains cx.buf in one read.",
+			hdr)
+	}
+	if hdr[1] != 0x03 || hdr[2] != 0x01 {
+		t.Errorf("TLS record version bytes look wrong: hdr=% x (want 16 03 01 ..)", hdr)
+	}
+
+	// Read the full record body — catches the byte-loss variant. Under
+	// the original 256-byte bufio (or any sizing < cx.buf length), this
+	// EOFs mid-body because cx.buf's unread tail was dropped on the
+	// floor or rendered unreachable to the wrapped conn.
+	bodyLen := int(uint16(hdr[3])<<8 | uint16(hdr[4]))
+	body := make([]byte, bodyLen)
+	n2, readErr2 := io.ReadFull(wrappedCx, body)
+	if readErr2 != nil {
+		t.Fatalf("ReadFull(record body, len=%d): n=%d err=%v — the proxy_protocol "+
+			"handler is dropping bytes that cx.buf had but proxyproto's bufio "+
+			"hadn't yet consumed; ensure proxyproto.NewConn is given "+
+			"WithBufferSize(layer4.MaxBufLen).", bodyLen, n2, readErr2)
+	}
+	// First handshake byte should be the ClientHello type (0x01) we
+	// stamped at the start of the record body.
+	if body[0] != 0x01 {
+		t.Errorf("handshake header at body[0]=0x%02x, want 0x01 (ClientHello). "+
+			"Stream alignment is broken even though hdr[0]==0x16.", body[0])
+	}
+}
+
+// buildPROXYv2PlusFakeTLSPayload returns a PROXY v2 TCPv4 header (28
+// bytes) followed by a TLS handshake record whose body is the given
+// length. Body bytes after the 4-byte handshake header are filled
+// with 0xAA so any byte read past the record header is clearly
+// identifiable as mid-handshake-body filler.
+func buildPROXYv2PlusFakeTLSPayload(recordBodyLen int) []byte {
+	var p []byte
+
+	// PROXY v2 TCPv4 header (28 bytes total).
+	p = append(p,
+		0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A,
+		0x51, 0x55, 0x49, 0x54, 0x0A, // 12-byte signature
+	)
+	p = append(p, 0x21)                   // v2 + PROXY command
+	p = append(p, 0x11)                   // TCPv4
+	p = append(p, 0x00, 0x0C)             // 12 address bytes follow
+	p = append(p, 0x01, 0x02, 0x03, 0x04) // src 1.2.3.4
+	p = append(p, 0x05, 0x06, 0x07, 0x08) // dst 5.6.7.8
+	p = append(p, 0x30, 0x39)             // src port 12345
+	p = append(p, 0x01, 0xBB)             // dst port 443
+
+	// TLS handshake record: 5-byte header + recordBodyLen-byte body.
+	p = append(p, 0x16, 0x03, 0x01,
+		byte(recordBodyLen>>8), byte(recordBodyLen&0xFF))
+
+	body := make([]byte, recordBodyLen)
+	body[0] = 0x01 // handshake type: ClientHello
+	body[1] = byte((recordBodyLen - 4) >> 16)
+	body[2] = byte((recordBodyLen - 4) >> 8)
+	body[3] = byte((recordBodyLen - 4) & 0xFF)
+	for i := 4; i < len(body); i++ {
+		body[i] = 0xAA
+	}
+	p = append(p, body...)
+
+	return p
+}
+
+// buildPROXYv2PlusTwoFakeTLSRecordsPayload returns totalBytes of payload
+// shaped as: 28-byte PROXY v2 TCPv4 header + two back-to-back TLS
+// handshake records sized so the combined payload pushes cx.buf past
+// MaxMatchingBytes into the prefetchChunkSize-wide hole. The first
+// record is a ClientHello whose body is filled with 0xAA; the second
+// is a continuation record of the same shape. Used to exercise the
+// over-MaxMatchingBytes regime that the original (small-payload)
+// regression test cannot reach.
+//
+// Two records are necessary because TLSPlaintext.length is uint16 with
+// a hard ceiling at 2^14 (= 16 384) per RFC 8446 §5.1 — a single
+// 17 KiB record body is invalid. The handler doesn't care about record
+// validity (caddy-l4's TLS matcher does, but this test reads bytes
+// directly from the wrapped Connection), so any fragmentation works
+// as long as the first record header has the canonical TLS handshake
+// shape.
+func buildPROXYv2PlusTwoFakeTLSRecordsPayload(totalBytes int) []byte {
+	const (
+		proxyHdrLen = 28
+		tlsHdrLen   = 5
+	)
+
+	// Sized so record1 body + record2 (header + body) + proxy header == totalBytes.
+	// Split roughly in half, keeping each body within the 2^14-1 ceiling.
+	availForRecords := totalBytes - proxyHdrLen
+	record1BodyLen := (availForRecords - tlsHdrLen) / 2
+	record2BodyLen := availForRecords - record1BodyLen - 2*tlsHdrLen
+	if record1BodyLen > (1<<14)-1 || record2BodyLen > (1<<14)-1 {
+		panic("buildPROXYv2PlusTwoFakeTLSRecordsPayload: bodyLen exceeds TLS record ceiling")
+	}
+
+	var p []byte
+	p = append(p,
+		0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A,
+		0x51, 0x55, 0x49, 0x54, 0x0A,
+	)
+	p = append(p, 0x21, 0x11)
+	p = append(p, 0x00, 0x0C)
+	p = append(p, 0x01, 0x02, 0x03, 0x04)
+	p = append(p, 0x05, 0x06, 0x07, 0x08)
+	p = append(p, 0x30, 0x39)
+	p = append(p, 0x01, 0xBB)
+
+	// Record 1: TLS handshake (ClientHello shape).
+	p = append(p, 0x16, 0x03, 0x01,
+		byte(record1BodyLen>>8), byte(record1BodyLen&0xFF))
+	body1 := make([]byte, record1BodyLen)
+	body1[0] = 0x01 // ClientHello
+	body1[1] = byte((record1BodyLen - 4) >> 16)
+	body1[2] = byte((record1BodyLen - 4) >> 8)
+	body1[3] = byte((record1BodyLen - 4) & 0xFF)
+	for i := 4; i < len(body1); i++ {
+		body1[i] = 0xAA
+	}
+	p = append(p, body1...)
+
+	// Record 2: more handshake bytes; treated as opaque continuation.
+	p = append(p, 0x16, 0x03, 0x01,
+		byte(record2BodyLen>>8), byte(record2BodyLen&0xFF))
+	body2 := make([]byte, record2BodyLen)
+	for i := range body2 {
+		body2[i] = 0xBB
+	}
+	p = append(p, body2...)
+
+	return p
+}


### PR DESCRIPTION
Note: this PR was entirely LLM created, but it does fix a real bug we had. I don't have any expectations here, just wanted to report the bug with a potential fix. Feel free to close if you'd like!

## Summary

The bug, in five steps:

1. caddy-l4's routes matching loop prefetches bytes from the connection into `cx.buf` (up to ~18 KiB) so multiple matchers can each take a look at the same byte stream.
2. The `proxy_protocol` matcher matches, and the `proxy_protocol` handler runs `proxyproto.NewConn(cx)`. `pires/go-proxyproto`'s internal `bufio.Reader` is hard-coded to 256 bytes (see `protocol.go:
const readBufferSize = 256`).
3. To parse the PROXY header, bufio issues one `cx.Read` for 256 bytes. `cx.offset` advances to 256, but `cx.Read`'s reset branch (`!matching && offset == len(buf)`) doesn't fire because `cx.buf` is
longer than 256.
4. `cx.Wrap(conn)` carries `cx.buf` and `cx.offset` into the wrapped Connection — so the wrapped Connection inherits a stale, partially-consumed prefetch buffer whose front is now ~256 bytes past the
actual stream position.
5. The next matcher reads from `cx.buf[256:]` (mid-stream junk) and silently returns `(matched=false, err=nil)`; or, if it reads through `proxyproto.Conn` instead, gets the ~228 leftover bytes inside
bufio's private buffer and then blocks waiting for bytes that won't arrive — surfacing as a 3-second `ErrMatchingTimeout` in production.

The fix:

1. Add a new exported constant `layer4.MaxBufLen = MaxMatchingBytes + prefetchChunkSize` — the strict upper bound on `cx.buf` after all prefetch operations.
2. Pass `proxyproto.WithBufferSize(layer4.MaxBufLen)` to `proxyproto.NewConn`. Bufio's first fill now drains all of `cx.buf` in one `cx.Read`, the reset branch fires cleanly, `cx.buf` ends up empty,
and bufio holds the entire post-PROXY-header byte stream. Subsequent reads through `proxyproto.Conn.Read` return TLS bytes in stream order.

## How to reproduce on `master`

`modules/l4proxyprotocol/handler_test.go::TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher` (added in this PR) reproduces the bug end-to-end:

1. Pre-populate `cx.buf` with a PROXY v2 TCPv4 header + a TLS-shaped record (~1.8 KB total — the normal production ClientHello size).
2. Run `Handler.Handle` to consume the PROXY header.
3. Read 5 bytes from the wrapped Connection to mimic what `l4tls.MatchTLS.Match` does first.

On `master`, the read returns `0xAA 0xAA 0xAA 0xAA 0xAA` (mid-handshake-body filler) instead of `0x16 0x03 0x01 LL LL` (TLS record header). `l4tls.MatchTLS` returns `(false, nil)` because `hdr[0] !=
recordTypeHandshake`, the route doesn't match, and in production the connection drops with no error log.

A second test (`...LargePrefetch`) constructs a 17 KiB payload across two TLS records to exercise the `cx.buf > MaxMatchingBytes` regime (see "Why MaxBufLen, not MaxMatchingBytes" below).

## Root cause

Stepping through `cx`'s state in `connection.go`:

| Step | `cx.buf` | `cx.offset` | `cx.matching` |
|------|----------|-------------|----------------|
| After matching-loop prefetch | 1865 bytes | 0 | false |
| proxy_protocol matcher freeze | 1865 | 0 | true |
| ↳ matcher reads 12 sig bytes | 1865 | 12 | true |
| proxy_protocol matcher unfreeze | 1865 | 0 (rewound) | false |
| Handler: `proxyproto.NewConn(cx)` | 1865 | 0 | false |
| ↳ `conn.ProxyHeader()` triggers bufio fill: `cx.Read(p[:256])` | 1865 | **256** | false |
| ↳ `if !matching && offset == len(buf)` reset doesn't fire (256 ≠ 1865) | 1865 | 256 | false |
| ↳ parseHeader consumes ~28 bytes from bufio; ~228 stay in bufio's private buf | 1865 | 256 | false |
| `cx.Wrap(conn)` returns new Connection with `buf=1865, offset=256` | 1865 | 256 | false |

The wrapped Connection now has two disjoint regions of the original byte stream:

- `cx.buf[28:256]` — the ~228 bytes of TLS data inside `proxyproto.Conn`'s private bufio. Accessible only via `proxyproto.Conn.Read`.
- `cx.buf[256:1865]` — the remaining ~1609 bytes of TLS data still in `cx.buf`. Accessible only via direct `cx.Read`.

These overlap in stream position but live in different layers of the wrapper stack. Subsequent matchers:

- **read via `cx.buf` directly** (when matching is false and `cx.buf` has bytes — `connection.go:130-138`): get `cx.buf[256:261]`, which is bytes *228-232* of the TLS stream. The TLS record header is
at bytes 0-4. So `hdr[0]` is some middle-of-body byte, almost never `0x16`. `l4tls.MatchTLS.Match` returns `(false, nil)`. Connection drops silently with `read=N, written=0`.
- **read via `proxyproto.Conn`** (when matching is true and `cx.buf` is empty — bypass happens through `cx.Conn.Read`): get bufio's 228-byte leftover, then block waiting for `cx.Conn.Read` to return
more. With the inbound TCP socket already drained (the ClientHello was a single segment), the read blocks until `MatchingTimeout`.

`pires/go-proxyproto`'s 256-byte bufio is documented as "kept low to reduce per-connection memory overhead" — fine in isolation but the bug surfaces specifically at the caddy-l4 wrapper boundary,
where a larger external buffer expects to be drained in one read.

## Why `MaxBufLen`, not `MaxMatchingBytes`

A naive fix would size bufio to `MaxMatchingBytes` (16 KiB). That handles the common case but is **strictly undersized** for the worst-case `cx.buf`: `prefetch()` gates with `if len(cx.buf) <  MaxMatchingBytes` *before* the read, then appends up to `prefetchChunkSize` bytes on top. So `cx.buf` can reach `MaxMatchingBytes + prefetchChunkSize - 1` ≈ 18 KiB. 

Sizing bufio to `MaxMatchingBytes` (16 KiB) leaves a 2 KiB-wide hole where the same misalignment bug re-activates for any deployment that runs multiple prefetch iterations before the `proxy_protocol` handler executes (e.g. when another matcher is configured before `proxy_protocol` in the route list).

This PR adds `layer4.MaxBufLen = MaxMatchingBytes + prefetchChunkSize` as the strict upper bound, and uses it for the bufio sizing. The `LargePrefetch` regression test specifically exercises this regime — toggling the bufio between `MaxMatchingBytes` and `MaxBufLen` cleanly toggles the test red/green.

## The fix

```go
// In modules/l4proxyprotocol/handler.go's newConn:
opts = append(opts, proxyproto.WithBufferSize(layer4.MaxBufLen))
return proxyproto.NewConn(cx, opts...)
```

With bufio = `MaxBufLen`, its first fill drains all of `cx.buf` in one `cx.Read` regardless of how many prefetch iterations preceded the handler. `cx.Read`'s reset branch fires (`offset == len(buf)`),
 `cx.buf` is emptied, and bufio holds the entire prefetched chunk minus the PROXY header. Subsequent reads through `proxyproto.Conn.Read` return TLS bytes in stream order.

## Tests

Two regression tests in `modules/l4proxyprotocol/handler_test.go`:

- `TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher` — small payload (~1.8 KB, the typical production ClientHello). Catches:
  - **Misalignment variant**: `hdr[0]` would be `0xAA` filler if reads bypass bufio.
  - **Byte-loss variant**: full record body would EOF mid-read if `cx.buf` bytes are made unreachable. This second arm specifically catches a class of "fix" that drops `cx.buf` without putting its
unread bytes anywhere.
- `TestProxyProtocolHandleDoesNotLeaveStaleBufferForNextMatcher_LargePrefetch` — 17 KiB payload across two TLS records. Exercises the `cx.buf > MaxMatchingBytes` regime that the small test cannot
reach.

Existing handler tests are unaffected — they wrap an empty `cx.buf` so the prefetched-buffer code path doesn't exercise. Full suite (`go test ./...`) passes.

To verify the tests do what they claim:

```diff
- opts = append(opts, proxyproto.WithBufferSize(layer4.MaxBufLen))
+ // opts = append(opts, proxyproto.WithBufferSize(layer4.MaxBufLen))
```

Both regression tests fail at the first assertion with `hdr=0xAA…` / `hdr=0xBB…`.

```diff
- opts = append(opts, proxyproto.WithBufferSize(layer4.MaxBufLen))
+ opts = append(opts, proxyproto.WithBufferSize(layer4.MaxMatchingBytes))
```

The small-payload test passes; the `LargePrefetch` test fails with `hdr=0xBB…` (the second TLS record's body, served from `cx.buf[16384:]`).

## Backwards compatibility

No JSON schema change. No exported API removed. New exported `layer4.MaxBufLen` const added — purely additive. Existing handler tests pass unchanged.

## Memory

`MaxBufLen` is 18 KiB. The previous (buggy) sizing was 256 bytes, so this PR adds ~18 KiB per active proxy_protocol handler invocation. For typical deployments (O(1000s) concurrent connections behind a fronting LB sending PROXY headers), that's a few tens of MiB peak — well within budget. Connections that don't go through `proxy_protocol` are unaffected.

## Real-world impact

Discovered while triaging a production incident on a Caddy cluster fronted by Fly's `proxy_proto` handler: we'd enabled L4 SNI blocking on top of an existing HTTPS configuration and every TLS handshake started silently dropping. The 256-byte bufio size made the bug deterministic in production (browser ClientHellos are routinely 1-2 KB) but invisible to existing handler tests, which never construct a `cx` with a prefetched buffer.

Filing this upstream so anyone using `proxy_protocol` + a subsequent matcher (TLS, HTTP, or anything reading from the wrapped Connection) gets the fix without needing to maintain a fork.