### PR TITLE
l4proxy: add active HTTP health checks

### DIFF
--- a/docs/handlers/proxy.md
+++ b/docs/handlers/proxy.md
@@ -56,6 +56,22 @@ Active health check options include `health_interval`, `health_port` and `health
 - `health_rise` is the number of consecutive successful active health checks required to mark an unhealthy upstream
   healthy again (by default, `1`).
 
+By default an active health check is a raw TCP dial. It can instead probe over HTTP, which lets the proxy follow an
+application-level signal (e.g. a primary-election endpoint such as Patroni's `/primary`) rather than mere port
+liveness. The HTTP probe is enabled by setting `health_uri` and is configured with these options, which correspond to
+the `uri`, `expect_status`, `https` and `tls_skip_verify` fields of the `l4proxy.ActiveHealthChecks` structure:
+
+- `health_uri` is the request path for an HTTP `GET` health check (e.g. `/primary`). When set, the check is performed
+  over HTTP (on `health_port` if configured, otherwise the dial port) instead of a raw TCP dial;
+
+- `health_status` is the status code considered healthy (by default, `200`). A value below `100` is treated as a
+  status class, e.g. `2` matches any `2xx` response;
+
+- `health_https` performs the HTTP health check over TLS;
+
+- `health_tls_skip_verify` disables TLS certificate verification for an `health_https` check (useful with self-signed
+  certificates).
+
 **Passive health checks** monitor proxied connections for errors or timeouts. To minimally enable passive health checks,
 set `passive` field equal to an empty structure inside `health_checks` in a JSON configuration or include any passive
 health check option into a Caddyfile.

--- a/integration/caddyfile_adapt/gd_handler_proxy_health_http.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_proxy_health_http.caddytest
@@ -1,0 +1,54 @@
+{
+	layer4 {
+		:5432 {
+			route {
+				proxy upstream.local:5432 {
+					health_port 8008
+					health_uri /primary
+					health_status 2xx
+					health_https
+					health_tls_skip_verify
+				}
+			}
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"layer4": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":5432"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "proxy",
+									"health_checks": {
+										"active": {
+											"expect_status": 2,
+											"https": true,
+											"port": 8008,
+											"tls_skip_verify": true,
+											"uri": "/primary"
+										}
+									},
+									"upstreams": [
+										{
+											"dial": [
+												"upstream.local:5432"
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/l4proxy/healthchecks.go
+++ b/modules/l4proxy/healthchecks.go
@@ -16,9 +16,12 @@ package l4proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
 	"runtime/debug"
 	"time"
 
@@ -29,8 +32,10 @@ import (
 // HealthChecks configures active and passive health checks.
 type HealthChecks struct {
 	// Active health checks run in the background on a timer. To
-	// minimally enable active health checks, set either path or
-	// port (or both).
+	// minimally enable active health checks, set the interval; the
+	// default probe is a raw TCP dial. Set uri to probe over HTTP
+	// instead (matching expect_status), which lets the proxy follow
+	// an application-level signal such as a primary-election endpoint.
 	Active *ActiveHealthChecks `json:"active,omitempty"`
 
 	// Passive health checks monitor proxied connections for errors or timeouts.
@@ -46,6 +51,25 @@ type ActiveHealthChecks struct {
 	// The port to use (if different from the upstream's dial
 	// address) for health checks.
 	Port int `json:"port,omitempty"`
+
+	// URI is the request path for an HTTP health check, e.g. "/primary".
+	// When set, each check performs an HTTP GET against the upstream (on
+	// Port if configured, otherwise the dial port) and the upstream is
+	// considered healthy only if the response status matches ExpectStatus.
+	// When empty, the check is a raw TCP dial (the default behavior).
+	URI string `json:"uri,omitempty"`
+
+	// ExpectStatus is the HTTP status code considered healthy for an HTTP
+	// health check (default 200). A value below 100 is treated as a status
+	// class, so e.g. 2 matches any 2xx response.
+	ExpectStatus int `json:"expect_status,omitempty"`
+
+	// HTTPS performs the HTTP health check over TLS.
+	HTTPS bool `json:"https,omitempty"`
+
+	// TLSSkipVerify disables TLS certificate verification for an HTTPS
+	// health check (useful with self-signed certificates).
+	TLSSkipVerify bool `json:"tls_skip_verify,omitempty"`
 
 	// How frequently to perform active health checks (default 30s).
 	Interval caddy.Duration `json:"interval,omitempty"`
@@ -166,6 +190,14 @@ func (h *Handler) doActiveHealthCheck(upstream *Upstream, p *peer) error {
 	hostPort := addr.JoinHostPort(0)
 	timeout := time.Duration(h.HealthChecks.Active.Timeout)
 
+	// HTTP health check: GET the URI and match the response status. This lets
+	// the proxy follow an application-level signal (e.g. Patroni's /primary,
+	// which returns 200 only on the elected leader) instead of merely checking
+	// that a TCP port accepts connections.
+	if h.HealthChecks.Active.URI != "" {
+		return h.doActiveHTTPHealthCheck(p, hostPort, timeout)
+	}
+
 	// Resolve the destination address family only when it will actually be used,
 	// i.e. when the user has configured local_address or resolver_preference.
 	// Otherwise skip it to avoid an extra DNS lookup per health check for hostname upstreams.
@@ -237,4 +269,82 @@ func (h *Handler) doActiveHealthCheck(upstream *Upstream, p *peer) error {
 	h.metrics.setUpstreamHealthy(p.dialAddr, true)
 
 	return nil
+}
+
+// doActiveHTTPHealthCheck performs an HTTP GET against the peer at hostPort and
+// marks it healthy only if the response status matches the configured
+// ExpectStatus (default 200). It is used when ActiveHealthChecks.URI is set.
+func (h *Handler) doActiveHTTPHealthCheck(p *peer, hostPort string, timeout time.Duration) error {
+	scheme := "http"
+	if h.HealthChecks.Active.HTTPS {
+		scheme = "https"
+	}
+	u := scheme + "://" + hostPort + h.HealthChecks.Active.URI
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return fmt.Errorf("building health check request: %v", err)
+	}
+
+	client := &http.Client{Timeout: timeout}
+	if h.HealthChecks.Active.HTTPS && h.HealthChecks.Active.TLSSkipVerify {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // explicitly opted in
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		h.HealthChecks.Active.logger.Info("host is down",
+			zap.String("address", u),
+			zap.Duration("timeout", timeout),
+			zap.Error(err))
+		_, err2 := p.setHealthy(false)
+		if err2 != nil {
+			return fmt.Errorf("marking unhealthy: %v (original error: %v)", err2, err)
+		}
+		return nil
+	}
+	// Drain a bounded amount of the body and close it so the connection can be
+	// reused by keep-alive.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+	_ = resp.Body.Close()
+
+	expect := h.HealthChecks.Active.ExpectStatus
+	if expect == 0 {
+		expect = http.StatusOK
+	}
+	if !statusCodeMatches(resp.StatusCode, expect) {
+		h.HealthChecks.Active.logger.Info("host is down",
+			zap.String("address", u),
+			zap.Int("status", resp.StatusCode),
+			zap.Int("expect_status", expect))
+		_, err2 := p.setHealthy(false)
+		if err2 != nil {
+			return fmt.Errorf("marking unhealthy: %v", err2)
+		}
+		return nil
+	}
+
+	swapped, err := p.setHealthy(true)
+	if swapped {
+		h.HealthChecks.Active.logger.Info("host is up", zap.String("address", u))
+	}
+	if err != nil {
+		return fmt.Errorf("marking healthy: %v", err)
+	}
+	return nil
+}
+
+// statusCodeMatches reports whether status satisfies expect. If expect is below
+// 100 it is treated as a status class (e.g. 2 matches any 2xx response);
+// otherwise it must match exactly.
+func statusCodeMatches(status, expect int) bool {
+	if expect < 100 {
+		return status/100 == expect
+	}
+	return status == expect
 }

--- a/modules/l4proxy/healthchecks.go
+++ b/modules/l4proxy/healthchecks.go
@@ -302,10 +302,9 @@ func (h *Handler) doActiveHTTPHealthCheck(p *peer, hostPort string, timeout time
 			zap.String("address", u),
 			zap.Duration("timeout", timeout),
 			zap.Error(err))
-		_, err2 := p.setHealthy(false)
-		if err2 != nil {
-			return fmt.Errorf("marking unhealthy: %v (original error: %v)", err2, err)
-		}
+		// setHealthy never returns an error (it only reports whether the state
+		// changed), so the result is intentionally ignored here.
+		_, _ = p.setHealthy(false)
 		return nil
 	}
 	// Drain a bounded amount of the body and close it so the connection can be
@@ -322,19 +321,12 @@ func (h *Handler) doActiveHTTPHealthCheck(p *peer, hostPort string, timeout time
 			zap.String("address", u),
 			zap.Int("status", resp.StatusCode),
 			zap.Int("expect_status", expect))
-		_, err2 := p.setHealthy(false)
-		if err2 != nil {
-			return fmt.Errorf("marking unhealthy: %v", err2)
-		}
+		_, _ = p.setHealthy(false)
 		return nil
 	}
 
-	swapped, err := p.setHealthy(true)
-	if swapped {
+	if swapped, _ := p.setHealthy(true); swapped {
 		h.HealthChecks.Active.logger.Info("host is up", zap.String("address", u))
-	}
-	if err != nil {
-		return fmt.Errorf("marking healthy: %v", err)
 	}
 	return nil
 }

--- a/modules/l4proxy/healthchecks_test.go
+++ b/modules/l4proxy/healthchecks_test.go
@@ -1,0 +1,240 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
+)
+
+func httpHealthHandler(uri string, expect int) *Handler {
+	return &Handler{
+		HealthChecks: &HealthChecks{
+			Active: &ActiveHealthChecks{
+				URI:          uri,
+				ExpectStatus: expect,
+				Timeout:      caddy.Duration(2 * time.Second),
+				logger:       zap.NewNop(),
+			},
+		},
+	}
+}
+
+func TestActiveHTTPHealthCheckHealthyOnExpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/primary" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	h := httpHealthHandler("/primary", 0) // 0 => default 200
+	p := &peer{}
+	if _, err := p.setHealthy(false); err != nil { // start unhealthy
+		t.Fatalf("seeding unhealthy: %v", err)
+	}
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	if err := h.doActiveHTTPHealthCheck(p, hostPort, time.Second); err != nil {
+		t.Fatalf("health check returned error: %v", err)
+	}
+	if !p.healthy() {
+		t.Fatal("peer should be healthy after 200 on /primary")
+	}
+}
+
+func TestActiveHTTPHealthCheckUnhealthyOnWrongStatus(t *testing.T) {
+	// Mimics a replica: Patroni's /primary returns 503 when not the leader.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	h := httpHealthHandler("/primary", 0)
+	p := &peer{} // starts healthy
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	if err := h.doActiveHTTPHealthCheck(p, hostPort, time.Second); err != nil {
+		t.Fatalf("health check returned error: %v", err)
+	}
+	if p.healthy() {
+		t.Fatal("peer should be unhealthy after 503 on /primary")
+	}
+}
+
+func TestActiveHTTPHealthCheckUnhealthyOnDial(t *testing.T) {
+	h := httpHealthHandler("/primary", 0)
+	p := &peer{} // starts healthy
+
+	// Port 1 is not listening: the GET must fail and mark the peer down.
+	if err := h.doActiveHTTPHealthCheck(p, "127.0.0.1:1", 200*time.Millisecond); err != nil {
+		t.Fatalf("health check returned error: %v", err)
+	}
+	if p.healthy() {
+		t.Fatal("peer should be unhealthy when the connection is refused")
+	}
+}
+
+func TestStatusCodeMatches(t *testing.T) {
+	cases := []struct {
+		status, expect int
+		want           bool
+	}{
+		{200, 200, true},
+		{503, 200, false},
+		{204, 2, true},  // class match
+		{299, 2, true},  // class match
+		{301, 2, false}, // class mismatch
+		{301, 3, true},  // class match
+	}
+	for _, c := range cases {
+		if got := statusCodeMatches(c.status, c.expect); got != c.want {
+			t.Errorf("statusCodeMatches(%d, %d) = %v, want %v", c.status, c.expect, got, c.want)
+		}
+	}
+}
+
+func TestParseStatusCode(t *testing.T) {
+	ok := map[string]int{"200": 200, "404": 404, "2xx": 2, "5xx": 5}
+	for in, want := range ok {
+		got, err := parseStatusCode(in)
+		if err != nil {
+			t.Errorf("parseStatusCode(%q) unexpected error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseStatusCode(%q) = %d, want %d", in, got, want)
+		}
+	}
+	for _, in := range []string{"", "abc", "9xx", "xxx", "2x"} {
+		if _, err := parseStatusCode(in); err == nil {
+			t.Errorf("parseStatusCode(%q): expected error, got nil", in)
+		}
+	}
+}
+
+func TestActiveHTTPHealthCheckStatusClass(t *testing.T) {
+	// expect_status 2 (any 2xx); server returns 204.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	h := httpHealthHandler("/primary", 2)
+	p := &peer{}
+	if _, err := p.setHealthy(false); err != nil {
+		t.Fatalf("seeding unhealthy: %v", err)
+	}
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	if err := h.doActiveHTTPHealthCheck(p, hostPort, time.Second); err != nil {
+		t.Fatalf("health check returned error: %v", err)
+	}
+	if !p.healthy() {
+		t.Fatal("peer should be healthy after 204 with expect_status 2 (2xx class)")
+	}
+}
+
+func TestActiveHTTPSHealthCheck(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/primary" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	h := httpHealthHandler("/primary", 0)
+	h.HealthChecks.Active.HTTPS = true
+	h.HealthChecks.Active.TLSSkipVerify = true // httptest uses a self-signed cert
+	p := &peer{}
+	if _, err := p.setHealthy(false); err != nil {
+		t.Fatalf("seeding unhealthy: %v", err)
+	}
+
+	hostPort := strings.TrimPrefix(srv.URL, "https://")
+	if err := h.doActiveHTTPHealthCheck(p, hostPort, time.Second); err != nil {
+		t.Fatalf("https health check returned error: %v", err)
+	}
+	if !p.healthy() {
+		t.Fatal("peer should be healthy after 200 over HTTPS on /primary")
+	}
+}
+
+func TestActiveHTTPHealthCheckBadURI(t *testing.T) {
+	// A control character makes the request URL invalid, so building the
+	// request fails and the error is surfaced (rather than marking unhealthy).
+	h := httpHealthHandler("/\x7f", 0)
+	p := &peer{}
+	if err := h.doActiveHTTPHealthCheck(p, "127.0.0.1:9", time.Second); err == nil {
+		t.Fatal("expected an error building the request for an invalid URI")
+	}
+}
+
+func TestUnmarshalCaddyfileHTTPHealthCheck(t *testing.T) {
+	d := caddyfile.NewTestDispenser(`proxy localhost:5432 {
+		health_uri /primary
+		health_status 2xx
+		health_https
+		health_tls_skip_verify
+	}`)
+	h := new(Handler)
+	if err := h.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile: %v", err)
+	}
+	if h.HealthChecks == nil || h.HealthChecks.Active == nil {
+		t.Fatal("expected active health checks to be configured")
+	}
+	a := h.HealthChecks.Active
+	if a.URI != "/primary" {
+		t.Errorf("URI = %q, want /primary", a.URI)
+	}
+	if a.ExpectStatus != 2 {
+		t.Errorf("ExpectStatus = %d, want 2", a.ExpectStatus)
+	}
+	if !a.HTTPS {
+		t.Error("HTTPS = false, want true")
+	}
+	if !a.TLSSkipVerify {
+		t.Error("TLSSkipVerify = false, want true")
+	}
+}
+
+func TestUnmarshalCaddyfileHTTPHealthCheckErrors(t *testing.T) {
+	cases := map[string]string{
+		"duplicate health_uri":   "proxy localhost:5432 {\n\thealth_uri /a\n\thealth_uri /b\n}",
+		"bad health_status":      "proxy localhost:5432 {\n\thealth_status nope\n}",
+		"health_uri missing arg": "proxy localhost:5432 {\n\thealth_uri\n}",
+		"health_https with arg":  "proxy localhost:5432 {\n\thealth_https yes\n}",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := new(Handler)
+			if err := h.UnmarshalCaddyfile(caddyfile.NewTestDispenser(input)); err == nil {
+				t.Fatalf("expected error for %q, got nil", name)
+			}
+		})
+	}
+}

--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -515,6 +515,10 @@ func (h *Handler) Cleanup() error {
 //		health_fall <int>
 //		health_rise <int>
 //		close_if_unhealthy
+//		health_uri <path>
+//		health_status <code|class>
+//		health_https
+//		health_tls_skip_verify
 //
 //		# passive health check options
 //		fail_duration <duration>
@@ -545,6 +549,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	var (
 		hasHealthInterval, hasHealthPort, hasHealthTimeout  bool // active health check options
 		hasHealthFall, hasHealthRise, hasCloseIfUnhealthy   bool // active health check thresholds
+		hasHealthURI, hasHealthStatus                       bool // active HTTP health check options
 		hasFailDuration, hasMaxFails, hasUnhealthyConnCount bool // passive health check options
 		hasLBPolicy, hasLBTryDuration, hasLBTryInterval     bool // load balancing options
 		hasProxyProtocol                                    bool
@@ -642,6 +647,58 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.HealthChecks.Active = &ActiveHealthChecks{}
 			}
 			h.HealthChecks.Active.Rise, hasHealthRise = int(val), true
+		case "health_uri":
+			if hasHealthURI {
+				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
+			}
+			if d.CountRemainingArgs() != 1 {
+				return d.ArgErr()
+			}
+			d.NextArg()
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
+			}
+			h.HealthChecks.Active.URI, hasHealthURI = d.Val(), true
+		case "health_status":
+			if hasHealthStatus {
+				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
+			}
+			if d.CountRemainingArgs() != 1 {
+				return d.ArgErr()
+			}
+			d.NextArg()
+			status, err := parseStatusCode(d.Val())
+			if err != nil {
+				return d.Errf("parsing %s option '%s': %v", wrapper, optionName, err)
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
+			}
+			h.HealthChecks.Active.ExpectStatus, hasHealthStatus = status, true
+		case "health_https":
+			if d.CountRemainingArgs() != 0 {
+				return d.ArgErr()
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
+			}
+			h.HealthChecks.Active.HTTPS = true
+		case "health_tls_skip_verify":
+			if d.CountRemainingArgs() != 0 {
+				return d.ArgErr()
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
+			}
+			h.HealthChecks.Active.TLSSkipVerify = true
 		case "fail_duration":
 			if hasFailDuration {
 				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
@@ -797,6 +854,23 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 // allows the state of remote hosts to be preserved
 // through config reloads.
 var peers = caddy.NewUsagePool()
+
+// parseStatusCode parses the health_status Caddyfile value. It accepts a full
+// status code ("200") or a status class in "Nxx" form ("2xx"), the latter
+// returned as the single class digit (e.g. 2), matching ExpectStatus semantics.
+func parseStatusCode(s string) (int, error) {
+	if len(s) == 3 && (s[1] == 'x' || s[1] == 'X') && (s[2] == 'x' || s[2] == 'X') {
+		if s[0] >= '1' && s[0] <= '5' {
+			return int(s[0] - '0'), nil
+		}
+		return 0, fmt.Errorf("invalid status class %q", s)
+	}
+	code, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid status code %q", s)
+	}
+	return code, nil
+}
 
 // Interface guards
 var (


### PR DESCRIPTION
## What

Adds an optional HTTP mode to the layer4 proxy's active health checks. Today the active health check only performs a raw TCP dial, so it can tell whether a port is open but nothing about the application-level state behind it.

New `ActiveHealthChecks` fields (JSON):
- `uri` — request path; when set, the check performs an HTTP `GET` instead of a TCP dial
- `expect_status` — healthy status code, or a class (e.g. `2` matches any 2xx); default `200`
- `https` — perform the check over TLS
- `tls_skip_verify` — skip TLS verification (useful with self-signed certs)

Caddyfile equivalents: `health_uri`, `health_status` (accepts `200` or `2xx`), `health_https`, `health_tls_skip_verify`.

When `uri` is unset the check stays a raw TCP dial, so existing behavior is unchanged.

## Why

It lets a layer4 proxy follow an application-level signal instead of mere port-liveness. For example, Patroni (PostgreSQL HA) exposes `/primary`, which returns `200` only on the elected leader; with this change the proxy can route to whichever upstream is currently primary and follow failover automatically — something the TCP-only check cannot do, since every node accepts TCP connections regardless of role.

## Tests

Added `healthchecks_test.go`: healthy/unhealthy by status, status-class match, HTTPS (self-signed), connection-refused, invalid-URI, and Caddyfile parsing (happy + error paths). `go test ./modules/l4proxy/` passes; `gofmt` and `go vet` are clean.
