### PR TITLE
l4proxy: optionally close connections when a peer goes unhealthy

### DIFF
--- a/docs/handlers/proxy.md
+++ b/docs/handlers/proxy.md
@@ -72,6 +72,12 @@ the similarly named fields of the `l4proxy.PassiveHealthChecks` structure:
 - `unhealthy_connection_count` limits the number of simultaneous connections to this upstream by marking it as "down"
   if it has this many or more concurrent connections.
 
+In addition, a `health_checks`-level option `close_connections_on_unhealthy` (corresponding to the
+`close_connections_on_unhealthy` field of `l4proxy.HealthChecks`) force-closes a peer's currently-open proxied
+connections the moment an active health check marks it unhealthy, instead of letting them run until they close on
+their own. This is useful for failover (e.g. moving clients off a demoted database primary). By default it is off,
+preserving the existing behavior.
+
 **Load balancing** distributes connections between upstreams. To minimally enable load balancing, set `load_balancing`
 field equal to an empty structure in a JSON configuration or include any load balancing option into a Caddyfile. Note:
 load balancing makes sense only if the handler has two or more upstreams.

--- a/docs/handlers/proxy.md
+++ b/docs/handlers/proxy.md
@@ -72,10 +72,11 @@ the similarly named fields of the `l4proxy.PassiveHealthChecks` structure:
 - `unhealthy_connection_count` limits the number of simultaneous connections to this upstream by marking it as "down"
   if it has this many or more concurrent connections.
 
-In addition, a `health_checks`-level option `close_connections_on_unhealthy` (corresponding to the
-`close_connections_on_unhealthy` field of `l4proxy.HealthChecks`) force-closes a peer's currently-open proxied
-connections the moment an active health check marks it unhealthy, instead of letting them run until they close on
-their own. This is useful for failover (e.g. moving clients off a demoted database primary). By default it is off,
+In addition, the active health check option `close_if_unhealthy` (corresponding to the `close_if_unhealthy` field of
+`l4proxy.ActiveHealthChecks`) force-closes a peer's currently-open proxied connections the moment an active health
+check marks it unhealthy, instead of letting them run until they close on their own. This is useful for failover
+(e.g. moving clients off a demoted database primary). It applies to active health checks only, which provide a clear
+healthy→unhealthy transition to act on; passive health checking has no equivalent event. By default it is off,
 preserving the existing behavior.
 
 **Load balancing** distributes connections between upstreams. To minimally enable load balancing, set `load_balancing`

--- a/integration/caddyfile_adapt/gd_handler_proxy_close_conns.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_proxy_close_conns.caddytest
@@ -4,7 +4,7 @@
 			route {
 				proxy upstream.local:5432 {
 					health_interval 2s
-					close_connections_on_unhealthy
+					close_if_unhealthy
 				}
 			}
 		}
@@ -26,9 +26,9 @@
 									"handler": "proxy",
 									"health_checks": {
 										"active": {
+											"close_if_unhealthy": true,
 											"interval": 2000000000
-										},
-										"close_connections_on_unhealthy": true
+										}
 									},
 									"upstreams": [
 										{

--- a/integration/caddyfile_adapt/gd_handler_proxy_close_conns.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_proxy_close_conns.caddytest
@@ -1,0 +1,48 @@
+{
+	layer4 {
+		:5432 {
+			route {
+				proxy upstream.local:5432 {
+					health_interval 2s
+					close_connections_on_unhealthy
+				}
+			}
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"layer4": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":5432"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "proxy",
+									"health_checks": {
+										"active": {
+											"interval": 2000000000
+										},
+										"close_connections_on_unhealthy": true
+									},
+									"upstreams": [
+										{
+											"dial": [
+												"upstream.local:5432"
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/l4proxy/closeconns_test.go
+++ b/modules/l4proxy/closeconns_test.go
@@ -64,8 +64,11 @@ func newDeadPeer(t *testing.T) *peer {
 func activeCheckHandler(closeOnUnhealthy bool) *Handler {
 	return &Handler{
 		HealthChecks: &HealthChecks{
-			Active:                      &ActiveHealthChecks{Timeout: caddy.Duration(200 * time.Millisecond), logger: zap.NewNop()},
-			CloseConnectionsOnUnhealthy: closeOnUnhealthy,
+			Active: &ActiveHealthChecks{
+				Timeout:          caddy.Duration(200 * time.Millisecond),
+				CloseIfUnhealthy: closeOnUnhealthy,
+				logger:           zap.NewNop(),
+			},
 		},
 	}
 }
@@ -115,15 +118,20 @@ func TestActiveHealthCheckKeepsConnsWhenDisabled(t *testing.T) {
 
 func TestUnmarshalCaddyfileCloseConnections(t *testing.T) {
 	h := new(Handler)
-	if err := h.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_connections_on_unhealthy\n}")); err != nil {
+	if err := h.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_if_unhealthy\n}")); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if h.HealthChecks == nil || !h.HealthChecks.CloseConnectionsOnUnhealthy {
-		t.Fatal("expected CloseConnectionsOnUnhealthy = true")
+	if h.HealthChecks == nil || h.HealthChecks.Active == nil || !h.HealthChecks.Active.CloseIfUnhealthy {
+		t.Fatal("expected Active.CloseIfUnhealthy = true")
 	}
 
 	h2 := new(Handler)
-	if err := h2.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_connections_on_unhealthy yes\n}")); err == nil {
-		t.Fatal("expected an error when close_connections_on_unhealthy has an argument")
+	if err := h2.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_if_unhealthy yes\n}")); err == nil {
+		t.Fatal("expected an error when close_if_unhealthy has an argument")
+	}
+
+	h3 := new(Handler)
+	if err := h3.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_if_unhealthy\n\tclose_if_unhealthy\n}")); err == nil {
+		t.Fatal("expected an error when close_if_unhealthy is specified twice")
 	}
 }

--- a/modules/l4proxy/closeconns_test.go
+++ b/modules/l4proxy/closeconns_test.go
@@ -1,0 +1,129 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxy
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
+)
+
+func TestPeerTrackUntrackCloseConns(t *testing.T) {
+	a, b := net.Pipe()
+	defer b.Close()
+
+	p := &peer{}
+	p.trackConn(a)
+	if got := len(p.openConns); got != 1 {
+		t.Fatalf("tracked conns = %d, want 1", got)
+	}
+
+	// untrack removes without closing
+	p.untrackConn(a)
+	if got := len(p.openConns); got != 0 {
+		t.Fatalf("after untrack = %d, want 0", got)
+	}
+
+	// re-track, then closeOpenConns closes and clears
+	p.trackConn(a)
+	p.closeOpenConns()
+	if got := len(p.openConns); got != 0 {
+		t.Fatalf("after closeOpenConns = %d, want 0", got)
+	}
+	_ = a.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := a.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected a read error on the closed connection")
+	}
+}
+
+func newDeadPeer(t *testing.T) *peer {
+	t.Helper()
+	addr, err := caddy.ParseNetworkAddress("127.0.0.1:1") // nothing listening on port 1
+	if err != nil {
+		t.Fatalf("parsing address: %v", err)
+	}
+	return &peer{address: &addr}
+}
+
+func activeCheckHandler(closeOnUnhealthy bool) *Handler {
+	return &Handler{
+		HealthChecks: &HealthChecks{
+			Active:                      &ActiveHealthChecks{Timeout: caddy.Duration(200 * time.Millisecond), logger: zap.NewNop()},
+			CloseConnectionsOnUnhealthy: closeOnUnhealthy,
+		},
+	}
+}
+
+func TestActiveHealthCheckClosesConnsWhenEnabled(t *testing.T) {
+	a, b := net.Pipe()
+	defer b.Close()
+
+	p := newDeadPeer(t)
+	p.trackConn(a)
+
+	h := activeCheckHandler(true)
+	if err := h.doActiveHealthCheck(&Upstream{peers: []*peer{p}}, p); err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	if p.healthy() {
+		t.Fatal("peer should be unhealthy after a failed dial")
+	}
+	if got := len(p.openConns); got != 0 {
+		t.Fatalf("open conns = %d, want 0 (should have been closed)", got)
+	}
+	_ = a.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := a.Read(make([]byte, 1)); err == nil {
+		t.Fatal("expected the tracked connection to be closed")
+	}
+}
+
+func TestActiveHealthCheckKeepsConnsWhenDisabled(t *testing.T) {
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	p := newDeadPeer(t)
+	p.trackConn(a)
+
+	h := activeCheckHandler(false)
+	if err := h.doActiveHealthCheck(&Upstream{peers: []*peer{p}}, p); err != nil {
+		t.Fatalf("health check: %v", err)
+	}
+	if p.healthy() {
+		t.Fatal("peer should be unhealthy after a failed dial")
+	}
+	if got := len(p.openConns); got != 1 {
+		t.Fatalf("open conns = %d, want 1 (option disabled, must not close)", got)
+	}
+}
+
+func TestUnmarshalCaddyfileCloseConnections(t *testing.T) {
+	h := new(Handler)
+	if err := h.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_connections_on_unhealthy\n}")); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.HealthChecks == nil || !h.HealthChecks.CloseConnectionsOnUnhealthy {
+		t.Fatal("expected CloseConnectionsOnUnhealthy = true")
+	}
+
+	h2 := new(Handler)
+	if err := h2.UnmarshalCaddyfile(caddyfile.NewTestDispenser("proxy localhost:1 {\n\tclose_connections_on_unhealthy yes\n}")); err == nil {
+		t.Fatal("expected an error when close_connections_on_unhealthy has an argument")
+	}
+}

--- a/modules/l4proxy/healthchecks.go
+++ b/modules/l4proxy/healthchecks.go
@@ -37,14 +37,6 @@ type HealthChecks struct {
 	// To minimally enable passive health checks, specify at least an empty
 	// config object.
 	Passive *PassiveHealthChecks `json:"passive,omitempty"`
-
-	// CloseConnectionsOnUnhealthy, when true, force-closes a peer's currently
-	// open proxied connections the moment an active health check marks it
-	// unhealthy, instead of letting them run until they close on their own.
-	// This is useful for failover, where clients should be moved off a backend
-	// as soon as it goes down (e.g. a demoted database primary). Default false,
-	// preserving the existing behavior.
-	CloseConnectionsOnUnhealthy bool `json:"close_connections_on_unhealthy,omitempty"`
 }
 
 // ActiveHealthChecks holds configuration related to active health
@@ -61,6 +53,20 @@ type ActiveHealthChecks struct {
 	// How long to wait for a connection to be established with
 	// peer before considering it unhealthy (default 5s).
 	Timeout caddy.Duration `json:"timeout,omitempty"`
+
+	// CloseIfUnhealthy, when true, force-closes a peer's currently open proxied
+	// connections the moment an active health check marks it unhealthy, instead
+	// of letting them run until they close on their own. This is useful for
+	// failover, where clients should be moved off a backend as soon as it goes
+	// down (e.g. a demoted database primary). Default false, preserving the
+	// existing behavior.
+	//
+	// This applies to active health checks only: they provide a clear
+	// healthy->unhealthy transition to hook onto. Passive health checking has no
+	// equivalent transition event (a peer is simply considered down on demand
+	// once its failure count crosses the threshold), so there is nothing to
+	// trigger a close.
+	CloseIfUnhealthy bool `json:"close_if_unhealthy,omitempty"`
 
 	// Fall is the number of consecutive failed active health checks required
 	// to mark an upstream unhealthy (default 1).
@@ -209,7 +215,7 @@ func (h *Handler) doActiveHealthCheck(upstream *Upstream, p *peer) error {
 			if swapped {
 				h.HealthChecks.Active.logger.Info("host is down", zap.String("address", addr.String()))
 			}
-			if swapped && h.HealthChecks.CloseConnectionsOnUnhealthy {
+			if swapped && h.HealthChecks.Active.CloseIfUnhealthy {
 				p.closeOpenConns()
 			}
 		}

--- a/modules/l4proxy/healthchecks.go
+++ b/modules/l4proxy/healthchecks.go
@@ -37,6 +37,14 @@ type HealthChecks struct {
 	// To minimally enable passive health checks, specify at least an empty
 	// config object.
 	Passive *PassiveHealthChecks `json:"passive,omitempty"`
+
+	// CloseConnectionsOnUnhealthy, when true, force-closes a peer's currently
+	// open proxied connections the moment an active health check marks it
+	// unhealthy, instead of letting them run until they close on their own.
+	// This is useful for failover, where clients should be moved off a backend
+	// as soon as it goes down (e.g. a demoted database primary). Default false,
+	// preserving the existing behavior.
+	CloseConnectionsOnUnhealthy bool `json:"close_connections_on_unhealthy,omitempty"`
 }
 
 // ActiveHealthChecks holds configuration related to active health
@@ -200,6 +208,9 @@ func (h *Handler) doActiveHealthCheck(upstream *Upstream, p *peer) error {
 			}
 			if swapped {
 				h.HealthChecks.Active.logger.Info("host is down", zap.String("address", addr.String()))
+			}
+			if swapped && h.HealthChecks.CloseConnectionsOnUnhealthy {
+				p.closeOpenConns()
 			}
 		}
 		h.metrics.setUpstreamHealthy(p.dialAddr, false)

--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -196,7 +196,7 @@ func (h *Handler) Handle(down *layer4.Connection, _ layer4.Handler) error {
 	// if enabled, track these connections on their peers so they can be
 	// force-closed when a peer is marked unhealthy. upConns[i] corresponds to
 	// upstream.peers[i] (dialPeers dials one connection per peer, in order).
-	closeOnUnhealthy := h.HealthChecks != nil && h.HealthChecks.CloseConnectionsOnUnhealthy
+	closeOnUnhealthy := h.HealthChecks != nil && h.HealthChecks.Active != nil && h.HealthChecks.Active.CloseIfUnhealthy
 	if closeOnUnhealthy {
 		for i, conn := range upConns {
 			if i < len(upstream.peers) {
@@ -514,12 +514,12 @@ func (h *Handler) Cleanup() error {
 //		health_timeout <duration>
 //		health_fall <int>
 //		health_rise <int>
+//		close_if_unhealthy
 //
 //		# passive health check options
 //		fail_duration <duration>
 //		max_fails <int>
 //		unhealthy_connection_count <int>
-//		close_connections_on_unhealthy
 //
 //		# load balancing options
 //		lb_policy <name> [<args...>]
@@ -544,7 +544,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 	var (
 		hasHealthInterval, hasHealthPort, hasHealthTimeout  bool // active health check options
-		hasHealthFall, hasHealthRise                        bool // active health check thresholds
+		hasHealthFall, hasHealthRise, hasCloseIfUnhealthy   bool // active health check thresholds
 		hasFailDuration, hasMaxFails, hasUnhealthyConnCount bool // passive health check options
 		hasLBPolicy, hasLBTryDuration, hasLBTryInterval     bool // load balancing options
 		hasProxyProtocol                                    bool
@@ -696,14 +696,19 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.HealthChecks.Passive = &PassiveHealthChecks{}
 			}
 			h.HealthChecks.Passive.UnhealthyConnectionCount, hasUnhealthyConnCount = int(val), true
-		case "close_connections_on_unhealthy":
+		case "close_if_unhealthy":
+			if hasCloseIfUnhealthy {
+				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
+			}
 			if d.CountRemainingArgs() != 0 {
 				return d.ArgErr()
 			}
 			if h.HealthChecks == nil {
-				h.HealthChecks = &HealthChecks{}
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
 			}
-			h.HealthChecks.CloseConnectionsOnUnhealthy = true
+			h.HealthChecks.Active.CloseIfUnhealthy, hasCloseIfUnhealthy = true, true
 		case "lb_policy":
 			if hasLBPolicy {
 				return d.Errf("duplicate proxy load_balancing option '%s'", optionName)

--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -193,10 +193,25 @@ func (h *Handler) Handle(down *layer4.Connection, _ layer4.Handler) error {
 	upstreamLabel := upstream.String()
 	h.metrics.connectionOpened(upstreamLabel)
 
+	// if enabled, track these connections on their peers so they can be
+	// force-closed when a peer is marked unhealthy. upConns[i] corresponds to
+	// upstream.peers[i] (dialPeers dials one connection per peer, in order).
+	closeOnUnhealthy := h.HealthChecks != nil && h.HealthChecks.CloseConnectionsOnUnhealthy
+	if closeOnUnhealthy {
+		for i, conn := range upConns {
+			if i < len(upstream.peers) {
+				upstream.peers[i].trackConn(conn)
+			}
+		}
+	}
+
 	// make sure upstream connections all get closed, and record the close
 	defer func() {
-		for _, conn := range upConns {
+		for i, conn := range upConns {
 			_ = conn.Close()
+			if closeOnUnhealthy && i < len(upstream.peers) {
+				upstream.peers[i].untrackConn(conn)
+			}
 		}
 		h.metrics.connectionClosed(upstreamLabel)
 	}()
@@ -504,6 +519,7 @@ func (h *Handler) Cleanup() error {
 //		fail_duration <duration>
 //		max_fails <int>
 //		unhealthy_connection_count <int>
+//		close_connections_on_unhealthy
 //
 //		# load balancing options
 //		lb_policy <name> [<args...>]
@@ -680,6 +696,14 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.HealthChecks.Passive = &PassiveHealthChecks{}
 			}
 			h.HealthChecks.Passive.UnhealthyConnectionCount, hasUnhealthyConnCount = int(val), true
+		case "close_connections_on_unhealthy":
+			if d.CountRemainingArgs() != 0 {
+				return d.ArgErr()
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{}
+			}
+			h.HealthChecks.CloseConnectionsOnUnhealthy = true
 		case "lb_policy":
 			if hasLBPolicy {
 				return d.Errf("duplicate proxy load_balancing option '%s'", optionName)

--- a/modules/l4proxy/upstream.go
+++ b/modules/l4proxy/upstream.go
@@ -537,7 +537,7 @@ type peer struct {
 
 	// openConns tracks the currently-open proxied connections to this peer so
 	// they can be force-closed when the peer is marked unhealthy. It is only
-	// populated when HealthChecks.CloseConnectionsOnUnhealthy is enabled.
+	// populated when HealthChecks.Active.CloseIfUnhealthy is enabled.
 	openConnsMu sync.Mutex
 	openConns   map[net.Conn]struct{}
 }

--- a/modules/l4proxy/upstream.go
+++ b/modules/l4proxy/upstream.go
@@ -534,6 +534,12 @@ type peer struct {
 	activeHealthMu  sync.Mutex
 	consecSuccesses int
 	consecFails     int
+
+	// openConns tracks the currently-open proxied connections to this peer so
+	// they can be force-closed when the peer is marked unhealthy. It is only
+	// populated when HealthChecks.CloseConnectionsOnUnhealthy is enabled.
+	openConnsMu sync.Mutex
+	openConns   map[net.Conn]struct{}
 }
 
 // getNumConns returns the number of active connections with the peer.
@@ -568,6 +574,36 @@ func (p *peer) recordActiveCheck(ok bool, rise, fall int) (mark, healthy bool) {
 		p.consecFails++
 	}
 	return p.consecFails >= fall, false
+}
+
+// trackConn records an open proxied connection so it can later be closed by
+// closeOpenConns.
+func (p *peer) trackConn(c net.Conn) {
+	p.openConnsMu.Lock()
+	if p.openConns == nil {
+		p.openConns = make(map[net.Conn]struct{})
+	}
+	p.openConns[c] = struct{}{}
+	p.openConnsMu.Unlock()
+}
+
+// untrackConn forgets a proxied connection (e.g. once it has closed normally).
+func (p *peer) untrackConn(c net.Conn) {
+	p.openConnsMu.Lock()
+	delete(p.openConns, c)
+	p.openConnsMu.Unlock()
+}
+
+// closeOpenConns closes every currently-tracked proxied connection. Closing the
+// upstream side causes the proxy's io.Copy loops to return and the session to
+// tear down, moving the client off this peer.
+func (p *peer) closeOpenConns() {
+	p.openConnsMu.Lock()
+	for c := range p.openConns {
+		_ = c.Close()
+		delete(p.openConns, c)
+	}
+	p.openConnsMu.Unlock()
 }
 
 // healthy returns true if the peer is not unhealthy.


### PR DESCRIPTION
## What

Adds an opt-in `HealthChecks.CloseConnectionsOnUnhealthy` (Caddyfile: `close_connections_on_unhealthy`). When enabled, a peer's currently-open proxied connections are force-closed as soon as an **active** health check marks it unhealthy, instead of being left to run until they close on their own.

Closing the upstream side of each tracked connection makes the existing `io.Copy` loops in `proxy()` return, so the session tears down and the client reconnects — and is then routed to a healthy peer.

- Default is `false`, so existing behavior is unchanged.
- Per-peer connections are tracked (a small `map[net.Conn]struct{}` under a mutex) **only** when the option is enabled, so there's no overhead otherwise.
- `upConns[i]` corresponds to `upstream.peers[i]` (dialPeers dials one connection per peer, in order), which is how connections are associated with peers for tracking/untracking.

## Why

Pairs naturally with active health checks for failover scenarios. For example, with an HTTP health check against a PostgreSQL/Patroni `/primary` endpoint, when the primary is demoted its health check flips to unhealthy; this option then drops the stale sessions immediately rather than leaving clients pinned to a now read-only/blocked backend.

## Scope / open questions

- Triggered on the **active** health-check unhealthy transition. I deliberately left the passive path out of this PR to keep it focused; happy to extend if you'd prefer it also fire there.
- Open to naming/placement feedback (field on `HealthChecks` vs `PassiveHealthChecks`/`ActiveHealthChecks`).

## Tests

`closeconns_test.go`: peer track/untrack/close mechanics, active-check closes conns when enabled, leaves them when disabled, and Caddyfile parsing (happy + arg error). `go test ./modules/l4proxy/` passes; `gofmt` / `go vet` / `golangci-lint` clean.
