### PR TITLE
l4proxy: add rise/fall thresholds to active health checks

### DIFF
--- a/docs/handlers/proxy.md
+++ b/docs/handlers/proxy.md
@@ -38,7 +38,13 @@ Active health check options include `health_interval`, `health_port` and `health
 - `health_port` is the port to use (if different from the upstream's dial address) for active health checks;
 
 - `health_timeout` sets how long to wait for a connection to be established with a peer (one of the dial addresses)
-  before considering it unhealthy (by default, it equals `5s`).
+  before considering it unhealthy (by default, it equals `5s`);
+
+- `health_fall` is the number of consecutive failed active health checks required to mark an upstream unhealthy
+  (by default, `1`). Raising it smooths over transient blips (HAProxy-style hysteresis);
+
+- `health_rise` is the number of consecutive successful active health checks required to mark an unhealthy upstream
+  healthy again (by default, `1`).
 
 **Passive health checks** monitor proxied connections for errors or timeouts. To minimally enable passive health checks,
 set `passive` field equal to an empty structure inside `health_checks` in a JSON configuration or include any passive

--- a/integration/caddyfile_adapt/gd_handler_proxy_health_rise_fall.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_proxy_health_rise_fall.caddytest
@@ -1,0 +1,50 @@
+{
+	layer4 {
+		:5432 {
+			route {
+				proxy upstream.local:5432 {
+					health_interval 2s
+					health_fall 3
+					health_rise 2
+				}
+			}
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"layer4": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":5432"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "proxy",
+									"health_checks": {
+										"active": {
+											"fall": 3,
+											"interval": 2000000000,
+											"rise": 2
+										}
+									},
+									"upstreams": [
+										{
+											"dial": [
+												"upstream.local:5432"
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/l4proxy/healthchecks.go
+++ b/modules/l4proxy/healthchecks.go
@@ -54,6 +54,14 @@ type ActiveHealthChecks struct {
 	// peer before considering it unhealthy (default 5s).
 	Timeout caddy.Duration `json:"timeout,omitempty"`
 
+	// Fall is the number of consecutive failed active health checks required
+	// to mark an upstream unhealthy (default 1).
+	Fall int `json:"fall,omitempty"`
+
+	// Rise is the number of consecutive successful active health checks
+	// required to mark an unhealthy upstream healthy again (default 1).
+	Rise int `json:"rise,omitempty"`
+
 	logger *zap.Logger
 }
 
@@ -179,26 +187,34 @@ func (h *Handler) doActiveHealthCheck(upstream *Upstream, p *peer) error {
 			}
 		}
 	}
+	rise, fall := h.HealthChecks.Active.Rise, h.HealthChecks.Active.Fall
 	if err != nil {
-		h.HealthChecks.Active.logger.Info("host is down",
+		h.HealthChecks.Active.logger.Info("active health check failed",
 			zap.String("address", addr.String()),
 			zap.Duration("timeout", timeout),
 			zap.Error(err))
-		_, err2 := p.setHealthy(false)
-		if err2 != nil {
-			return fmt.Errorf("marking unhealthy: %v (original error: %v)", err2, err)
+		if mark, healthy := p.recordActiveCheck(false, rise, fall); mark {
+			swapped, err2 := p.setHealthy(healthy)
+			if err2 != nil {
+				return fmt.Errorf("marking unhealthy: %v (original error: %v)", err2, err)
+			}
+			if swapped {
+				h.HealthChecks.Active.logger.Info("host is down", zap.String("address", addr.String()))
+			}
 		}
 		return nil
 	}
 	_ = conn.Close()
 
-	// connection succeeded, so mark as healthy
-	swapped, err := p.setHealthy(true)
-	if swapped {
-		h.HealthChecks.Active.logger.Info("host is up", zap.String("address", addr.String()))
-	}
-	if err != nil {
-		return fmt.Errorf("marking healthy: %v", err)
+	// connection succeeded
+	if mark, healthy := p.recordActiveCheck(true, rise, fall); mark {
+		swapped, err := p.setHealthy(healthy)
+		if err != nil {
+			return fmt.Errorf("marking healthy: %v", err)
+		}
+		if swapped {
+			h.HealthChecks.Active.logger.Info("host is up", zap.String("address", addr.String()))
+		}
 	}
 
 	return nil

--- a/modules/l4proxy/proxy.go
+++ b/modules/l4proxy/proxy.go
@@ -489,6 +489,8 @@ func (h *Handler) Cleanup() error {
 //		health_interval <duration>
 //		health_port <int>
 //		health_timeout <duration>
+//		health_fall <int>
+//		health_rise <int>
 //
 //		# passive health check options
 //		fail_duration <duration>
@@ -518,6 +520,7 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 
 	var (
 		hasHealthInterval, hasHealthPort, hasHealthTimeout  bool // active health check options
+		hasHealthFall, hasHealthRise                        bool // active health check thresholds
 		hasFailDuration, hasMaxFails, hasUnhealthyConnCount bool // passive health check options
 		hasLBPolicy, hasLBTryDuration, hasLBTryInterval     bool // load balancing options
 		hasProxyProtocol                                    bool
@@ -579,6 +582,42 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				h.HealthChecks.Active = &ActiveHealthChecks{}
 			}
 			h.HealthChecks.Active.Timeout, hasHealthTimeout = caddy.Duration(dur), true
+		case "health_fall":
+			if hasHealthFall {
+				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
+			}
+			if d.CountRemainingArgs() != 1 {
+				return d.ArgErr()
+			}
+			d.NextArg()
+			val, err := strconv.ParseInt(d.Val(), 10, 32)
+			if err != nil {
+				return d.Errf("parsing %s option '%s': %v", wrapper, optionName, err)
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
+			}
+			h.HealthChecks.Active.Fall, hasHealthFall = int(val), true
+		case "health_rise":
+			if hasHealthRise {
+				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
+			}
+			if d.CountRemainingArgs() != 1 {
+				return d.ArgErr()
+			}
+			d.NextArg()
+			val, err := strconv.ParseInt(d.Val(), 10, 32)
+			if err != nil {
+				return d.Errf("parsing %s option '%s': %v", wrapper, optionName, err)
+			}
+			if h.HealthChecks == nil {
+				h.HealthChecks = &HealthChecks{Active: &ActiveHealthChecks{}}
+			} else if h.HealthChecks.Active == nil {
+				h.HealthChecks.Active = &ActiveHealthChecks{}
+			}
+			h.HealthChecks.Active.Rise, hasHealthRise = int(val), true
 		case "fail_duration":
 			if hasFailDuration {
 				return d.Errf("duplicate %s option '%s'", wrapper, optionName)

--- a/modules/l4proxy/risefall_test.go
+++ b/modules/l4proxy/risefall_test.go
@@ -1,0 +1,116 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"go.uber.org/zap"
+)
+
+func TestRecordActiveCheckThresholds(t *testing.T) {
+	p := &peer{}
+
+	// fall=3: three consecutive failures are required to mark unhealthy.
+	if mark, _ := p.recordActiveCheck(false, 2, 3); mark {
+		t.Fatal("1 failure must not mark with fall=3")
+	}
+	if mark, _ := p.recordActiveCheck(false, 2, 3); mark {
+		t.Fatal("2 failures must not mark with fall=3")
+	}
+	if mark, healthy := p.recordActiveCheck(false, 2, 3); !mark || healthy {
+		t.Fatalf("3 failures must mark unhealthy; got mark=%v healthy=%v", mark, healthy)
+	}
+
+	// A success resets the failure streak; rise=2 requires two successes.
+	if mark, _ := p.recordActiveCheck(true, 2, 3); mark {
+		t.Fatal("1 success must not mark with rise=2")
+	}
+	if mark, healthy := p.recordActiveCheck(true, 2, 3); !mark || !healthy {
+		t.Fatalf("2 successes must mark healthy; got mark=%v healthy=%v", mark, healthy)
+	}
+
+	// A failure resets the success streak again.
+	if mark, _ := p.recordActiveCheck(false, 2, 3); mark {
+		t.Fatal("1 failure after recovery must not mark with fall=3")
+	}
+}
+
+func TestRecordActiveCheckDefaultsToSingle(t *testing.T) {
+	p := &peer{}
+	if mark, healthy := p.recordActiveCheck(false, 0, 0); !mark || healthy {
+		t.Fatalf("a single failure must mark unhealthy with defaults; mark=%v healthy=%v", mark, healthy)
+	}
+	if mark, healthy := p.recordActiveCheck(true, 0, 0); !mark || !healthy {
+		t.Fatalf("a single success must mark healthy with defaults; mark=%v healthy=%v", mark, healthy)
+	}
+}
+
+func TestActiveHealthCheckFallThreshold(t *testing.T) {
+	addr, err := caddy.ParseNetworkAddress("127.0.0.1:1") // nothing listening on port 1
+	if err != nil {
+		t.Fatalf("parsing address: %v", err)
+	}
+	p := &peer{address: &addr}
+	h := &Handler{HealthChecks: &HealthChecks{Active: &ActiveHealthChecks{
+		Timeout: caddy.Duration(200 * time.Millisecond),
+		Fall:    2,
+		logger:  zap.NewNop(),
+	}}}
+	up := &Upstream{peers: []*peer{p}}
+
+	if err := h.doActiveHealthCheck(up, p); err != nil {
+		t.Fatalf("check 1: %v", err)
+	}
+	if !p.healthy() {
+		t.Fatal("peer should still be healthy after 1 failure with fall=2")
+	}
+	if err := h.doActiveHealthCheck(up, p); err != nil {
+		t.Fatalf("check 2: %v", err)
+	}
+	if p.healthy() {
+		t.Fatal("peer should be unhealthy after 2 failures with fall=2")
+	}
+}
+
+func TestUnmarshalCaddyfileRiseFall(t *testing.T) {
+	d := caddyfile.NewTestDispenser("proxy localhost:1 {\n\thealth_fall 3\n\thealth_rise 2\n}")
+	h := new(Handler)
+	if err := h.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.HealthChecks.Active.Fall != 3 {
+		t.Errorf("Fall = %d, want 3", h.HealthChecks.Active.Fall)
+	}
+	if h.HealthChecks.Active.Rise != 2 {
+		t.Errorf("Rise = %d, want 2", h.HealthChecks.Active.Rise)
+	}
+
+	cases := map[string]string{
+		"duplicate health_fall": "proxy localhost:1 {\n\thealth_fall 1\n\thealth_fall 2\n}",
+		"bad health_rise":       "proxy localhost:1 {\n\thealth_rise nope\n}",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := new(Handler)
+			if err := h.UnmarshalCaddyfile(caddyfile.NewTestDispenser(input)); err == nil {
+				t.Fatalf("expected an error for %q, got nil", name)
+			}
+		})
+	}
+}

--- a/modules/l4proxy/upstream.go
+++ b/modules/l4proxy/upstream.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/caddyserver/caddy/v2"
@@ -509,11 +510,46 @@ type peer struct {
 	fails     atomic.Int32
 	address   *caddy.NetworkAddress
 	dialAddr  string
+
+	// activeHealthMu guards the consecutive active-health-check streak counters
+	// used to apply the rise/fall thresholds.
+	activeHealthMu  sync.Mutex
+	consecSuccesses int
+	consecFails     int
 }
 
 // getNumConns returns the number of active connections with the peer.
 func (p *peer) getNumConns() int {
 	return int(p.numConns.Load())
+}
+
+// recordActiveCheck folds one active-health-check result into the peer's
+// consecutive-success / consecutive-failure streaks and reports whether the
+// peer's health should be marked, honoring the rise/fall thresholds. A streak
+// of `rise` successes marks the peer healthy; a streak of `fall` failures marks
+// it unhealthy. rise/fall below 1 are treated as 1 (flip on a single result,
+// the default behavior). Counters are capped at the threshold to stay bounded.
+func (p *peer) recordActiveCheck(ok bool, rise, fall int) (mark, healthy bool) {
+	if rise < 1 {
+		rise = 1
+	}
+	if fall < 1 {
+		fall = 1
+	}
+	p.activeHealthMu.Lock()
+	defer p.activeHealthMu.Unlock()
+	if ok {
+		p.consecFails = 0
+		if p.consecSuccesses < rise {
+			p.consecSuccesses++
+		}
+		return p.consecSuccesses >= rise, true
+	}
+	p.consecSuccesses = 0
+	if p.consecFails < fall {
+		p.consecFails++
+	}
+	return p.consecFails >= fall, false
 }
 
 // healthy returns true if the peer is not unhealthy.


### PR DESCRIPTION
## What

Adds HAProxy-style `rise`/`fall` thresholds to the active health checker:

- `fall` (Caddyfile `health_fall <int>`) — number of **consecutive failed** checks before a peer is marked unhealthy.
- `rise` (Caddyfile `health_rise <int>`) — number of **consecutive successful** checks before an unhealthy peer is marked healthy again.

Both default to `1`, which is exactly the current behavior (flip on the first result), so this is fully backward compatible.

## Why

Today the checker calls `setHealthy` on every individual check, so a single transient failure (or success) immediately flips a peer's state. That makes health flap on a brief blip — undesirable, e.g. for database failover where a momentary timeout shouldn't trigger a switchover. `fall 3` / `rise 2` smooths that out.

## Implementation

Per-peer consecutive-success / consecutive-failure streaks tracked under a mutex (`recordActiveCheck`), capped at the threshold so the counters stay bounded. A streak reaching `fall` marks unhealthy; reaching `rise` marks healthy.

## Tests

`risefall_test.go`: streak logic (incl. reset on opposite result and the default-to-1 behavior), an end-to-end fall threshold via `doActiveHealthCheck`, and Caddyfile parsing (happy + duplicate/invalid errors). `go test ./modules/l4proxy/` passes; `gofmt` / `go vet` / `golangci-lint` clean.
