### PR TITLE
l4proxy: add weighted load balancing

### DIFF
--- a/docs/handlers/proxy.md
+++ b/docs/handlers/proxy.md
@@ -72,7 +72,9 @@ Load balancing options include `lb_policy`, `lb_try_duration` and `lb_try_interv
   - `random_choose` is a policy that selects two or more available hosts at random, then chooses the one with
     the least load (Caddyfile syntax is `random_choose [<int>]` with the argument setting the count of available
     hosts to be chosen at random before considering their load);
-  - `round_robin` is a policy that selects an upstream based on round-robin ordering.
+  - `round_robin` is a policy that selects an upstream based on round-robin ordering;
+  - `weighted_round_robin` is a policy that selects upstreams in smooth weighted round-robin order, proportional to
+    each upstream's `weight` (see the `weight` field below; an unset or non-positive weight is treated as `1`).
 
 - `lb_try_duration` defines how long to try selecting available upstreams for each connection if the next available
   host is down. By default, this retry is disabled. Clients will wait for up to this long while the load balancer
@@ -120,6 +122,9 @@ Each `upstream` has the following fields:
 
 - `max_connections` may contain an integer value representing how many connections this upstream is allowed to have
   before being marked as unhealthy (if more than 0).
+
+- `weight` may contain an integer giving this upstream's relative weight for the `weighted_round_robin` load-balancing
+  policy. A value less than or equal to `0` is treated as `1`. It is ignored by the other policies.
 
 - `tls` may contain a `reverseproxy.TLSConfig` structure to enable TLS when connecting to this upstream. Refer to the
   [relevant Caddy documentation](https://caddyserver.com/docs/json/apps/http/servers/routes/handle/reverse_proxy/transport/http/tls/)

--- a/integration/caddyfile_adapt/gd_handler_proxy_weighted_lb.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_proxy_weighted_lb.caddytest
@@ -1,0 +1,59 @@
+{
+	layer4 {
+		:5432 {
+			route {
+				proxy {
+					lb_policy weighted_round_robin
+					upstream 10.0.0.1:5432 {
+						weight 3
+					}
+					upstream 10.0.0.2:5432 {
+						weight 1
+					}
+				}
+			}
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"layer4": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":5432"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "proxy",
+									"load_balancing": {
+										"selection": {
+											"policy": "weighted_round_robin"
+										}
+									},
+									"upstreams": [
+										{
+											"dial": [
+												"10.0.0.1:5432"
+											],
+											"weight": 3
+										},
+										{
+											"dial": [
+												"10.0.0.2:5432"
+											],
+											"weight": 1
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/modules/l4proxy/loadbalancing.go
+++ b/modules/l4proxy/loadbalancing.go
@@ -21,6 +21,7 @@ import (
 	weakrand "math/rand/v2"
 	"net"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -81,6 +82,7 @@ func init() {
 	caddy.RegisterModule(&RandomChoiceSelection{})
 	caddy.RegisterModule(&LeastConnSelection{})
 	caddy.RegisterModule(&RoundRobinSelection{})
+	caddy.RegisterModule(&WeightedRoundRobinSelection{})
 	caddy.RegisterModule(&FirstSelection{})
 	caddy.RegisterModule(&IPHashSelection{})
 }
@@ -326,6 +328,75 @@ func (r *RoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	return nil
 }
 
+// WeightedRoundRobinSelection is a policy that selects available hosts in a
+// smooth weighted round-robin order, proportional to each upstream's Weight
+// (an unset or non-positive weight is treated as 1).
+type WeightedRoundRobinSelection struct {
+	mu      sync.Mutex
+	current []int
+}
+
+// CaddyModule returns the Caddy module information.
+func (*WeightedRoundRobinSelection) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.proxy.selection_policies.weighted_round_robin",
+		New: func() caddy.Module { return new(WeightedRoundRobinSelection) },
+	}
+}
+
+// Select returns an available host, if any, using smooth weighted round-robin
+// (the same algorithm nginx uses): each call adds every available host's weight
+// to its current counter, picks the host with the highest counter, then
+// subtracts the total weight from the winner's counter.
+func (w *WeightedRoundRobinSelection) Select(pool UpstreamPool, _ *layer4.Connection) *Upstream {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if len(w.current) != len(pool) {
+		w.current = make([]int, len(pool))
+	}
+
+	total, best := 0, -1
+	for i, up := range pool {
+		if !up.available() {
+			continue
+		}
+		weight := up.Weight
+		if weight <= 0 {
+			weight = 1
+		}
+		w.current[i] += weight
+		total += weight
+		if best == -1 || w.current[i] > w.current[best] {
+			best = i
+		}
+	}
+	if best == -1 {
+		return nil
+	}
+	w.current[best] -= total
+	return pool[best]
+}
+
+// UnmarshalCaddyfile sets up the WeightedRoundRobinSelection from Caddyfile tokens. Syntax:
+//
+//	weighted_round_robin
+func (w *WeightedRoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	_, wrapper := d.Next(), d.Val() // consume wrapper name
+
+	// No same-line options are supported
+	if d.CountRemainingArgs() > 0 {
+		return d.ArgErr()
+	}
+
+	// No blocks are supported
+	if d.NextBlock(d.Nesting()) {
+		return d.Errf("malformed %s selection policy: blocks are not supported", wrapper)
+	}
+
+	return nil
+}
+
 // FirstSelection is a policy that selects
 // the first available host.
 type FirstSelection struct{}
@@ -467,6 +538,7 @@ var (
 	_ Selector = (*RandomChoiceSelection)(nil)
 	_ Selector = (*LeastConnSelection)(nil)
 	_ Selector = (*RoundRobinSelection)(nil)
+	_ Selector = (*WeightedRoundRobinSelection)(nil)
 	_ Selector = (*FirstSelection)(nil)
 	_ Selector = (*IPHashSelection)(nil)
 
@@ -477,6 +549,7 @@ var (
 	_ caddyfile.Unmarshaler = (*RandomChoiceSelection)(nil)
 	_ caddyfile.Unmarshaler = (*LeastConnSelection)(nil)
 	_ caddyfile.Unmarshaler = (*RoundRobinSelection)(nil)
+	_ caddyfile.Unmarshaler = (*WeightedRoundRobinSelection)(nil)
 	_ caddyfile.Unmarshaler = (*FirstSelection)(nil)
 	_ caddyfile.Unmarshaler = (*IPHashSelection)(nil)
 )

--- a/modules/l4proxy/upstream.go
+++ b/modules/l4proxy/upstream.go
@@ -86,6 +86,10 @@ type Upstream struct {
 	// have before being marked as unhealthy (if > 0).
 	MaxConnections int `json:"max_connections,omitempty"`
 
+	// Weight is this upstream's relative weight for weighted load-balancing
+	// policies (e.g. weighted_round_robin). A value <= 0 is treated as 1.
+	Weight int `json:"weight,omitempty"`
+
 	peers             []*peer
 	tlsConfig         *tls.Config
 	healthCheckPolicy *PassiveHealthChecks
@@ -289,6 +293,7 @@ func (u *Upstream) totalConns() int {
 //		local_addr <address[:port]> [<address[:port]>]
 //		resolver_preference <ipv4_only|ipv6_only|ipv4_first|ipv6_first>
 //		max_connections <int>
+//		weight <int>
 //
 //		tls
 //		tls_client_auth <automate_name> | <cert_file> <key_file>
@@ -312,7 +317,7 @@ func (u *Upstream) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		hasTLSTrustPool, hasTLSClientAuth       bool
 		hasTLSInsecureSkipVerify, hasTLSTimeout bool
 		hasTLSRenegotiation, hasTLSServerName   bool
-		hasResolverPreference                   bool
+		hasResolverPreference, hasWeight        bool
 	)
 	for nesting := d.Nesting(); d.NextBlock(nesting); {
 		optionName := d.Val()
@@ -356,6 +361,19 @@ func (u *Upstream) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Errf("parsing %s option '%s': %v", wrapper, optionName, err)
 			}
 			u.MaxConnections, hasMaxConnections = int(val), true
+		case "weight":
+			if hasWeight {
+				return d.Errf("duplicate %s option '%s'", wrapper, optionName)
+			}
+			if d.CountRemainingArgs() != 1 {
+				return d.ArgErr()
+			}
+			d.NextArg()
+			val, err := strconv.ParseInt(d.Val(), 10, 32)
+			if err != nil {
+				return d.Errf("parsing %s option '%s': %v", wrapper, optionName, err)
+			}
+			u.Weight, hasWeight = int(val), true
 		case "tls":
 			if hasTLS {
 				return d.Errf("duplicate %s option '%s'", wrapper, optionName)

--- a/modules/l4proxy/weighted_test.go
+++ b/modules/l4proxy/weighted_test.go
@@ -1,0 +1,122 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxy
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func healthyUpstream(weight int) *Upstream {
+	return &Upstream{Weight: weight, peers: []*peer{{}}}
+}
+
+func TestWeightedRoundRobinDistribution(t *testing.T) {
+	pool := UpstreamPool{healthyUpstream(1), healthyUpstream(2), healthyUpstream(3)}
+	w := new(WeightedRoundRobinSelection)
+
+	const cycles = 100 // total weight is 6, so each full cycle is 6 selections
+	counts := map[*Upstream]int{}
+	for range 6 * cycles {
+		u := w.Select(pool, nil)
+		if u == nil {
+			t.Fatal("unexpected nil selection")
+		}
+		counts[u]++
+	}
+
+	// Smooth weighted round-robin is exactly proportional over a full period.
+	want := map[*Upstream]int{pool[0]: 1 * cycles, pool[1]: 2 * cycles, pool[2]: 3 * cycles}
+	for u, c := range want {
+		if counts[u] != c {
+			t.Errorf("upstream weight %d: got %d selections, want %d", u.Weight, counts[u], c)
+		}
+	}
+}
+
+func TestWeightedRoundRobinDefaultsToOne(t *testing.T) {
+	// Unset weight (0) is treated as 1, so two upstreams split evenly.
+	pool := UpstreamPool{healthyUpstream(0), healthyUpstream(0)}
+	w := new(WeightedRoundRobinSelection)
+
+	counts := map[*Upstream]int{}
+	for range 200 {
+		counts[w.Select(pool, nil)]++
+	}
+	if counts[pool[0]] != 100 || counts[pool[1]] != 100 {
+		t.Errorf("even split expected, got %d / %d", counts[pool[0]], counts[pool[1]])
+	}
+}
+
+func TestWeightedRoundRobinSkipsUnavailable(t *testing.T) {
+	up := healthyUpstream(1)
+	down := healthyUpstream(5)
+	down.peers[0].setHealthy(false)
+
+	pool := UpstreamPool{up, down}
+	w := new(WeightedRoundRobinSelection)
+	for range 10 {
+		if got := w.Select(pool, nil); got != up {
+			t.Fatalf("expected only the available upstream to be selected, got %v", got)
+		}
+	}
+}
+
+func TestWeightedRoundRobinAllDownReturnsNil(t *testing.T) {
+	u := healthyUpstream(1)
+	u.peers[0].setHealthy(false)
+	w := new(WeightedRoundRobinSelection)
+	if got := w.Select(UpstreamPool{u}, nil); got != nil {
+		t.Fatalf("expected nil when all upstreams are down, got %v", got)
+	}
+}
+
+func TestUnmarshalCaddyfileWeighted(t *testing.T) {
+	d := caddyfile.NewTestDispenser("proxy {\n" +
+		"\tlb_policy weighted_round_robin\n" +
+		"\tupstream localhost:5432 {\n" +
+		"\t\tweight 3\n" +
+		"\t}\n" +
+		"}")
+	h := new(Handler)
+	if err := h.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(h.Upstreams) != 1 {
+		t.Fatalf("upstreams = %d, want 1", len(h.Upstreams))
+	}
+	if h.Upstreams[0].Weight != 3 {
+		t.Errorf("Weight = %d, want 3", h.Upstreams[0].Weight)
+	}
+	if h.LoadBalancing == nil || len(h.LoadBalancing.SelectionPolicyRaw) == 0 {
+		t.Error("expected weighted_round_robin selection policy to be set")
+	}
+}
+
+func TestUnmarshalCaddyfileWeightErrors(t *testing.T) {
+	cases := map[string]string{
+		"bad weight":       "proxy {\n\tupstream localhost:1 {\n\t\tweight nope\n\t}\n}",
+		"duplicate weight": "proxy {\n\tupstream localhost:1 {\n\t\tweight 1\n\t\tweight 2\n\t}\n}",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := new(Handler)
+			if err := h.UnmarshalCaddyfile(caddyfile.NewTestDispenser(input)); err == nil {
+				t.Fatalf("expected an error for %q, got nil", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds weighted load balancing to the layer4 proxy:

- **`Upstream.Weight`** (Caddyfile: `weight <int>` inside an `upstream` block). A value `<= 0` is treated as `1`.
- **`weighted_round_robin`** selection policy — smooth weighted round-robin (the same algorithm nginx uses), skipping unavailable peers.

Existing selection policies and configurations are unaffected.

Example:

```
proxy {
	lb_policy weighted_round_robin
	upstream 10.0.0.1:5432 { weight 3 }
	upstream 10.0.0.2:5432 { weight 1 }
}
```

## Why

Backends rarely have identical capacity. Weighted round-robin lets a bigger node take proportionally more traffic — one of HAProxy's most-used features, and something layer4's existing policies (random / round_robin / least_conn / first / ip_hash) couldn't express.

## Tests

`weighted_test.go`: exact proportional distribution over a full WRR period, default-to-1 behavior, skipping unavailable upstreams, all-down returns nil, and Caddyfile parsing (policy + `weight`, happy + error paths). `go test ./modules/l4proxy/` passes; `gofmt` / `go vet` / `golangci-lint` clean.
