### PR TITLE
l4metrics: add a connection metrics handler (#372)

### DIFF
--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -35,7 +35,8 @@ Handlers are categorized into different types based on their relationship with n
 |                       | [**echo**](/docs/handlers/echo.md)                     | Echo server, i.e. sends back exactly what it receives                                           |
 |                       | [**proxy**](/docs/handlers/proxy.md)                   | Layer 4 proxy, capable of multiple upstreams (with load balancing and health checks)            |
 |                       | [**socks5**](/docs/handlers/socks5.md)                 | [SOCKSv5](https://www.rfc-editor.org/rfc/rfc1928) server                                        |
-| Intermediary handlers | [**postgres_tls**](/docs/handlers/postgres_tls.md)     | Negotiating the Postgres `SSLRequest` preamble so `tls` can terminate classic Postgres TLS |
+| Intermediary handlers | [**metrics**](/docs/handlers/metrics.md)               | Recording per-connection traffic metrics (connection count, bytes received/sent) to Prometheus  |
+|                       | [**postgres_tls**](/docs/handlers/postgres_tls.md)     | Negotiating the Postgres `SSLRequest` preamble so `tls` can terminate classic Postgres TLS |
 |                       | [**proxy_protocol**](/docs/handlers/proxy_protocol.md) | Receiving [HAProxy Proxy Protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) |
 |                       | [**tls**](/docs/handlers/tls.md)                       | TLS termination                                                                                 |
 |                       | [**throttle**](/docs/handlers/throttle.md)             | Connection throttling to simulate slowness and latency                                          |

--- a/docs/handlers/metrics.md
+++ b/docs/handlers/metrics.md
@@ -1,0 +1,63 @@
+---
+title: Metrics Handler
+---
+
+# Metrics Handler
+
+## Summary
+
+The Metrics handler is a passthrough handler that records per-connection traffic
+metrics to Prometheus. It counts every connection that passes through it and,
+once the rest of the handler chain has finished, adds the connection's bytes
+received and sent to counters.
+
+Place it early in a route so it wraps the whole chain. Because layer4's byte
+accounting is kept on the underlying connection, the counts reflect the raw
+on-the-wire traffic even when a later handler (such as `tls`) terminates the
+connection.
+
+## Exported metrics
+
+All metrics are registered on Caddy's instance metrics registry (reset across
+config reloads) under the `caddy_layer4` subsystem:
+
+- `caddy_layer4_connections_total` — total number of connections handled through
+  the handler;
+- `caddy_layer4_received_bytes_total` — total number of bytes received from
+  clients;
+- `caddy_layer4_sent_bytes_total` — total number of bytes sent to clients.
+
+## Syntax
+
+The handler has no configurable fields.
+
+### Caddyfile
+
+The handler supports the following syntax:
+```caddyfile
+metrics
+```
+
+An example config that collects connection metrics for TCP port 5432 proxied to
+a Postgres backend:
+```caddyfile
+{
+    layer4 {
+        :5432 {
+            route {
+                metrics
+                proxy localhost:5433
+            }
+        }
+    }
+}
+```
+
+### JSON
+
+JSON equivalent to the handler in the config above:
+```json
+{
+    "handler": "metrics"
+}
+```

--- a/docs/handlers/metrics.md
+++ b/docs/handlers/metrics.md
@@ -61,3 +61,69 @@ JSON equivalent to the handler in the config above:
     "handler": "metrics"
 }
 ```
+
+## Scraping the metrics
+
+The `metrics` handler only *records* into Caddy's instance metrics registry — the
+same registry Caddy uses for its own metrics. Exposing that registry for a
+Prometheus scraper is done with Caddy's built-in metrics endpoints, so nothing
+extra is needed in the `layer4` app itself.
+
+There are two ways to expose it (see the [Caddy metrics docs](https://caddyserver.com/docs/metrics)):
+
+### 1. The admin endpoint (default, zero-config)
+
+Caddy permanently mounts a `/metrics` endpoint on its admin API (by default
+`http://localhost:2019/metrics`, local-only). Once the `metrics` handler is in a
+route, its counters appear there:
+
+```console
+$ curl -s localhost:2019/metrics | grep caddy_layer4
+# HELP caddy_layer4_connections_total Total number of connections handled through the metrics handler.
+# TYPE caddy_layer4_connections_total counter
+caddy_layer4_connections_total 3
+# HELP caddy_layer4_received_bytes_total Total number of bytes received from clients through the metrics handler.
+# TYPE caddy_layer4_received_bytes_total counter
+caddy_layer4_received_bytes_total 264
+# HELP caddy_layer4_sent_bytes_total Total number of bytes sent to clients through the metrics handler.
+# TYPE caddy_layer4_sent_bytes_total counter
+caddy_layer4_sent_bytes_total 191
+```
+
+### 2. A dedicated scrape endpoint (HTTP app)
+
+To expose the same metrics on a normal port (e.g. for a remote Prometheus),
+serve them with the HTTP app's [`metrics`](https://caddyserver.com/docs/caddyfile/directives/metrics)
+handler alongside the `layer4` app:
+
+```caddyfile
+{
+    layer4 {
+        :5432 {
+            route {
+                metrics
+                proxy localhost:5433
+            }
+        }
+    }
+}
+
+# a plain HTTP site that serves the shared registry for scraping
+:9180 {
+    metrics /metrics
+}
+```
+
+Then point Prometheus at it:
+
+```yaml
+scrape_configs:
+  - job_name: caddy-l4
+    static_configs:
+      - targets: ["localhost:9180"]
+```
+
+Because everything registers on the one shared registry, this endpoint also
+carries Caddy's own metrics (and the [`proxy`](proxy.md) handler's
+`caddy_layer4_proxy_*` metrics when that handler is used) next to the
+`caddy_layer4_*` counters above.

--- a/imports.go
+++ b/imports.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/mholt/caddy-l4/modules/l4dns"
 	_ "github.com/mholt/caddy-l4/modules/l4echo"
 	_ "github.com/mholt/caddy-l4/modules/l4http"
+	_ "github.com/mholt/caddy-l4/modules/l4metrics"
 	_ "github.com/mholt/caddy-l4/modules/l4openvpn"
 	_ "github.com/mholt/caddy-l4/modules/l4postgres"
 	_ "github.com/mholt/caddy-l4/modules/l4proxy"

--- a/integration/caddyfile_adapt/gd_handler_metrics.caddytest
+++ b/integration/caddyfile_adapt/gd_handler_metrics.caddytest
@@ -1,0 +1,43 @@
+{
+	layer4 {
+		:8080 {
+			route {
+				metrics
+				proxy backend:8080
+			}
+		}
+	}
+}
+----------
+{
+	"apps": {
+		"layer4": {
+			"servers": {
+				"srv0": {
+					"listen": [
+						":8080"
+					],
+					"routes": [
+						{
+							"handle": [
+								{
+									"handler": "metrics"
+								},
+								{
+									"handler": "proxy",
+									"upstreams": [
+										{
+											"dial": [
+												"backend:8080"
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			}
+		}
+	}
+}

--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -171,6 +171,17 @@ func (cx *Connection) Write(p []byte) (n int, err error) {
 	return
 }
 
+// BytesRead returns the total number of bytes read from the connection so far,
+// including any bytes consumed during matching. It enables handlers (e.g. a
+// metrics handler) to report per-connection traffic. It is not safe to call
+// concurrently with active reads; read it once the connection has finished (for
+// example after next.Handle returns).
+func (cx *Connection) BytesRead() uint64 { return cx.bytesRead }
+
+// BytesWritten returns the total number of bytes written to the connection so
+// far. See [Connection.BytesRead] for usage notes.
+func (cx *Connection) BytesWritten() uint64 { return cx.bytesWritten }
+
 // Wrap wraps conn in a new Connection based on cx (reusing
 // cx's existing buffer and context). This is useful after
 // a connection is wrapped by a package that does not support

--- a/layer4/connection_test.go
+++ b/layer4/connection_test.go
@@ -2,6 +2,7 @@ package layer4
 
 import (
 	"bytes"
+	"io"
 	"net"
 	"testing"
 
@@ -89,5 +90,34 @@ func TestConnection_FreezeAndUnfreeze(t *testing.T) {
 	}
 	if !bytes.Equal(consumeData, buf) {
 		t.Fatalf("expected %s but received %s", consumeData, buf)
+	}
+}
+
+func TestConnectionBytesReadWritten(t *testing.T) {
+	in, out := net.Pipe()
+	defer func() { _ = in.Close() }()
+	defer func() { _ = out.Close() }()
+
+	cx := WrapConnection(out, []byte{}, zap.NewNop())
+
+	go func() {
+		_, _ = in.Write([]byte("hello")) // 5 bytes for cx to read
+		reply := make([]byte, 3)
+		_, _ = io.ReadFull(in, reply) // consume the 3 bytes cx writes
+	}()
+
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(cx, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if _, err := cx.Write([]byte("bye")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := cx.BytesRead(); got != 5 {
+		t.Errorf("BytesRead() = %d, want 5", got)
+	}
+	if got := cx.BytesWritten(); got != 3 {
+		t.Errorf("BytesWritten() = %d, want 3", got)
 	}
 }

--- a/modules/l4metrics/metrics.go
+++ b/modules/l4metrics/metrics.go
@@ -17,10 +17,11 @@
 package l4metrics
 
 import (
+	"errors"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/mholt/caddy-l4/layer4"
 )
@@ -91,28 +92,49 @@ type metrics struct {
 	sentBytes        prometheus.Counter
 }
 
-// newMetrics creates and registers the connection metrics on reg.
+// registerOrExisting registers c on reg, or returns the already-registered
+// equivalent collector if an identical one is present. Multiple metrics handlers
+// in one config share the same instance registry, so the second and subsequent
+// Provision calls must reuse the collectors rather than panicking on a duplicate
+// registration.
+func registerOrExisting[C prometheus.Collector](reg *prometheus.Registry, c C) C {
+	if err := reg.Register(c); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(C); ok {
+				return existing
+			}
+		}
+		// Any other registration error means the metric is unusable; fall back to
+		// the unregistered collector so recording is a harmless no-op rather than
+		// crashing the whole server.
+	}
+	return c
+}
+
+// newMetrics creates and registers the connection metrics on reg, reusing any
+// collectors already registered there by another metrics handler.
 func newMetrics(reg *prometheus.Registry) *metrics {
 	const ns, sub = "caddy", "layer4"
 	return &metrics{
-		connectionsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		connectionsTotal: registerOrExisting(reg, prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "connections_total",
 			Help:      "Total number of connections handled through the metrics handler.",
-		}),
-		receivedBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		})),
+		receivedBytes: registerOrExisting(reg, prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "received_bytes_total",
 			Help:      "Total number of bytes received from clients through the metrics handler.",
-		}),
-		sentBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		})),
+		sentBytes: registerOrExisting(reg, prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "sent_bytes_total",
 			Help:      "Total number of bytes sent to clients through the metrics handler.",
-		}),
+		})),
 	}
 }
 

--- a/modules/l4metrics/metrics.go
+++ b/modules/l4metrics/metrics.go
@@ -1,0 +1,134 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package l4metrics provides a passthrough handler that records per-connection
+// traffic metrics (connection count and bytes received/sent) to Prometheus.
+package l4metrics
+
+import (
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/mholt/caddy-l4/layer4"
+)
+
+func init() {
+	caddy.RegisterModule(&Handler{})
+}
+
+// Handler is a passthrough handler that records per-connection traffic metrics.
+// It counts every connection that passes through it and, once the rest of the
+// handler chain has finished, adds the connection's bytes received and sent to
+// Prometheus counters. Place it early in a route so it wraps the whole chain;
+// because layer4's byte accounting is kept on the underlying connection, the
+// counts reflect the raw on-the-wire traffic even when a later handler (such as
+// tls) terminates the connection.
+type Handler struct {
+	metrics *metrics
+}
+
+// CaddyModule returns the Caddy module information.
+func (*Handler) CaddyModule() caddy.ModuleInfo {
+	return caddy.ModuleInfo{
+		ID:  "layer4.handlers.metrics",
+		New: func() caddy.Module { return new(Handler) },
+	}
+}
+
+// Provision sets up the handler.
+func (h *Handler) Provision(ctx caddy.Context) error {
+	h.metrics = newMetrics(ctx.GetMetricsRegistry())
+	return nil
+}
+
+// Handle handles the connection, recording its traffic once the rest of the
+// chain is done.
+func (h *Handler) Handle(cx *layer4.Connection, next layer4.Handler) error {
+	err := next.Handle(cx)
+	// The chain has finished, so the byte counters are final and no longer being
+	// mutated concurrently; it is safe to read them here.
+	h.metrics.record(cx.BytesRead(), cx.BytesWritten())
+	return err
+}
+
+// UnmarshalCaddyfile sets up the Handler from Caddyfile tokens. Syntax:
+//
+//	metrics
+func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	_, wrapper := d.Next(), d.Val() // consume wrapper name
+
+	// No same-line options are supported
+	if d.CountRemainingArgs() > 0 {
+		return d.ArgErr()
+	}
+
+	// No blocks are supported
+	if d.NextBlock(d.Nesting()) {
+		return d.Errf("malformed layer4 connection handler '%s': blocks are not supported", wrapper)
+	}
+	return nil
+}
+
+// metrics holds the Prometheus collectors for the metrics handler. They are
+// registered against the instance's metrics registry (obtained from the Caddy
+// context) so they reset cleanly across config reloads.
+type metrics struct {
+	connectionsTotal prometheus.Counter
+	receivedBytes    prometheus.Counter
+	sentBytes        prometheus.Counter
+}
+
+// newMetrics creates and registers the connection metrics on reg.
+func newMetrics(reg *prometheus.Registry) *metrics {
+	const ns, sub = "caddy", "layer4"
+	return &metrics{
+		connectionsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "connections_total",
+			Help:      "Total number of connections handled through the metrics handler.",
+		}),
+		receivedBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "received_bytes_total",
+			Help:      "Total number of bytes received from clients through the metrics handler.",
+		}),
+		sentBytes: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "sent_bytes_total",
+			Help:      "Total number of bytes sent to clients through the metrics handler.",
+		}),
+	}
+}
+
+// record adds one connection's traffic to the counters.
+func (m *metrics) record(read, written uint64) {
+	if m == nil {
+		return
+	}
+	m.connectionsTotal.Inc()
+	m.receivedBytes.Add(float64(read))
+	m.sentBytes.Add(float64(written))
+}
+
+// Interface guards
+var (
+	_ caddy.Provisioner     = (*Handler)(nil)
+	_ layer4.NextHandler    = (*Handler)(nil)
+	_ caddyfile.Unmarshaler = (*Handler)(nil)
+)

--- a/modules/l4metrics/metrics_test.go
+++ b/modules/l4metrics/metrics_test.go
@@ -1,0 +1,147 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+	"github.com/mholt/caddy-l4/layer4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+)
+
+func TestMetricsRecord(t *testing.T) {
+	m := newMetrics(prometheus.NewRegistry())
+
+	m.record(100, 40)
+	m.record(20, 10)
+
+	if got := testutil.ToFloat64(m.connectionsTotal); got != 2 {
+		t.Errorf("connections_total = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(m.receivedBytes); got != 120 {
+		t.Errorf("received_bytes_total = %v, want 120", got)
+	}
+	if got := testutil.ToFloat64(m.sentBytes); got != 50 {
+		t.Errorf("sent_bytes_total = %v, want 50", got)
+	}
+}
+
+func TestMetricsNilSafe(t *testing.T) {
+	var m *metrics // a handler that was never provisioned
+	m.record(1, 2)
+}
+
+func TestProvision(t *testing.T) {
+	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
+	defer cancel()
+
+	h := new(Handler)
+	if err := h.Provision(ctx); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if h.metrics == nil {
+		t.Fatal("expected metrics to be set after Provision")
+	}
+}
+
+// TestHandleRecordsTraffic drives a connection through the handler and checks
+// that the received/sent byte counts and the connection count are recorded.
+func TestHandleRecordsTraffic(t *testing.T) {
+	h := &Handler{metrics: newMetrics(prometheus.NewRegistry())}
+
+	client, server := net.Pipe()
+	defer client.Close()
+	cx := layer4.WrapConnection(server, []byte{}, zap.NewNop())
+
+	// The next handler reads 4 bytes from the client and writes 2 bytes back.
+	next := layer4.HandlerFunc(func(cx *layer4.Connection) error {
+		buf := make([]byte, 4)
+		if _, err := io.ReadFull(cx, buf); err != nil {
+			return err
+		}
+		_, err := cx.Write([]byte("hi"))
+		return err
+	})
+
+	go func() {
+		_, _ = client.Write([]byte("ping"))
+		reply := make([]byte, 2)
+		_, _ = io.ReadFull(client, reply)
+	}()
+
+	if err := h.Handle(cx, next); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	if got := testutil.ToFloat64(h.metrics.connectionsTotal); got != 1 {
+		t.Errorf("connections_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(h.metrics.receivedBytes); got != 4 {
+		t.Errorf("received_bytes_total = %v, want 4", got)
+	}
+	if got := testutil.ToFloat64(h.metrics.sentBytes); got != 2 {
+		t.Errorf("sent_bytes_total = %v, want 2", got)
+	}
+}
+
+// TestHandlePropagatesError verifies the next handler's error is returned while
+// the connection is still recorded.
+func TestHandlePropagatesError(t *testing.T) {
+	h := &Handler{metrics: newMetrics(prometheus.NewRegistry())}
+
+	_, server := net.Pipe()
+	cx := layer4.WrapConnection(server, []byte{}, zap.NewNop())
+
+	boom := errors.New("downstream failed")
+	next := layer4.HandlerFunc(func(*layer4.Connection) error { return boom })
+
+	if err := h.Handle(cx, next); !errors.Is(err, boom) {
+		t.Fatalf("Handle error = %v, want %v", err, boom)
+	}
+	if got := testutil.ToFloat64(h.metrics.connectionsTotal); got != 1 {
+		t.Errorf("connections_total = %v, want 1 (recorded even on error)", got)
+	}
+}
+
+func TestUnmarshalCaddyfile(t *testing.T) {
+	t.Run("bare", func(t *testing.T) {
+		d := caddyfile.NewTestDispenser(`metrics`)
+		if err := (&Handler{}).UnmarshalCaddyfile(d); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("args rejected", func(t *testing.T) {
+		d := caddyfile.NewTestDispenser(`metrics extra`)
+		if err := (&Handler{}).UnmarshalCaddyfile(d); err == nil {
+			t.Fatal("expected an error for arguments")
+		}
+	})
+
+	t.Run("block rejected", func(t *testing.T) {
+		d := caddyfile.NewTestDispenser("metrics {\n\tfoo\n}")
+		if err := (&Handler{}).UnmarshalCaddyfile(d); err == nil {
+			t.Fatal("expected an error for a block")
+		}
+	})
+}

--- a/modules/l4metrics/metrics_test.go
+++ b/modules/l4metrics/metrics_test.go
@@ -51,6 +51,29 @@ func TestMetricsNilSafe(t *testing.T) {
 	m.record(1, 2)
 }
 
+// TestMetricsDuplicateRegistration guards against the panic seen in issue #445:
+// multiple metrics handlers share one instance registry, so a second one must
+// reuse the existing collectors instead of panicking on a duplicate.
+func TestMetricsDuplicateRegistration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	m1 := newMetrics(reg)
+	m2 := newMetrics(reg) // must not panic
+
+	m1.record(10, 5)
+	m2.record(20, 7)
+
+	if got := testutil.ToFloat64(m1.connectionsTotal); got != 2 {
+		t.Errorf("connections_total = %v, want 2 (collectors must be shared)", got)
+	}
+	if got := testutil.ToFloat64(m1.receivedBytes); got != 30 {
+		t.Errorf("received_bytes_total = %v, want 30", got)
+	}
+	if m1.connectionsTotal != m2.connectionsTotal {
+		t.Error("expected the second handler to reuse the existing collector")
+	}
+}
+
 func TestProvision(t *testing.T) {
 	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
 	defer cancel()


### PR DESCRIPTION
Addresses #372 (connection stats metrics), following @vnxme's suggestion after #431.

## What

Two small pieces:

1. **Expose byte counters** — `layer4.Connection` already tracks `bytesRead`/`bytesWritten` (they're logged), but they weren't accessible to modules (the blocker noted in #372). This adds `Connection.BytesRead()` / `BytesWritten()` accessors.

2. **A `metrics` handler** (`layer4.handlers.metrics`) — a passthrough handler that counts each connection and, once the rest of the chain finishes, records its bytes received/sent to Prometheus:

   - `caddy_layer4_connections_total`
   - `caddy_layer4_received_bytes_total`
   - `caddy_layer4_sent_bytes_total`

   ```caddyfile
   route {
       metrics
       proxy localhost:5433
   }
   ```

## Notes

- Follows the same instance-registry pattern as the proxy metrics from #431 (`ctx.GetMetricsRegistry()`, reset across reloads, nil-safe).
- Place it early in a route so it wraps the whole chain. Because layer4 keeps byte accounting on the underlying connection, the counts reflect **raw on-the-wire** traffic even when a later `tls` handler terminates the connection.
- The accessors are documented as safe to read once the connection has finished (e.g. after `next.Handle` returns), which is exactly when the handler reads them.

## Verification

```
go test ./modules/l4metrics/ ./layer4/ ./integration/ -race
```

100% statement coverage of the new package; docs (`docs/handlers/metrics.md` + index) and a `caddyfile_adapt` test included. Happy to adjust metric names/shape (e.g. histograms instead of counters) to taste.