### PR TITLE
l4proxy: fix duplicate metrics registration panic (fixes #445)

### DIFF
--- a/modules/l4proxy/metrics.go
+++ b/modules/l4proxy/metrics.go
@@ -15,8 +15,9 @@
 package l4proxy
 
 import (
+	"errors"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // proxyMetrics holds the Prometheus collectors for a proxy handler. They are
@@ -28,28 +29,49 @@ type proxyMetrics struct {
 	upstreamHealthy  *prometheus.GaugeVec
 }
 
-// newProxyMetrics creates and registers the proxy metrics on reg.
+// registerOrExisting registers c on reg, or returns the already-registered
+// equivalent collector if an identical one is present. Several proxy handlers
+// in one config share the same instance registry, so the second and subsequent
+// Provision calls must reuse the collectors instead of panicking on a duplicate
+// registration (see issue #445).
+func registerOrExisting[C prometheus.Collector](reg *prometheus.Registry, c C) C {
+	if err := reg.Register(c); err != nil {
+		var are prometheus.AlreadyRegisteredError
+		if errors.As(err, &are) {
+			if existing, ok := are.ExistingCollector.(C); ok {
+				return existing
+			}
+		}
+		// Any other registration error means the metric is unusable; fall back to
+		// the unregistered collector so recording is a harmless no-op rather than
+		// crashing the whole server.
+	}
+	return c
+}
+
+// newProxyMetrics creates and registers the proxy metrics on reg, reusing any
+// collectors already registered there by another proxy handler.
 func newProxyMetrics(reg *prometheus.Registry) *proxyMetrics {
 	const ns, sub = "caddy", "layer4_proxy"
 	return &proxyMetrics{
-		connectionsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		connectionsTotal: registerOrExisting(reg, prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "connections_total",
 			Help:      "Total number of connections proxied, labeled by upstream.",
-		}, []string{"upstream"}),
-		activeConns: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		}, []string{"upstream"})),
+		activeConns: registerOrExisting(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "active_connections",
 			Help:      "Number of connections currently being proxied, labeled by upstream.",
-		}, []string{"upstream"}),
-		upstreamHealthy: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+		}, []string{"upstream"})),
+		upstreamHealthy: registerOrExisting(reg, prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,
 			Subsystem: sub,
 			Name:      "upstream_healthy",
 			Help:      "Whether an upstream is currently healthy (1) or down (0), per active health checks.",
-		}, []string{"upstream"}),
+		}, []string{"upstream"})),
 	}
 }
 

--- a/modules/l4proxy/metrics_test.go
+++ b/modules/l4proxy/metrics_test.go
@@ -63,6 +63,28 @@ func TestProxyMetricsNilSafe(t *testing.T) {
 	m.setUpstreamHealthy("x", true)
 }
 
+// TestProxyMetricsDuplicateRegistration reproduces issue #445: multiple proxy
+// handlers share one instance registry, so provisioning a second one must not
+// panic on a duplicate collector registration, and both must share the same
+// underlying collectors.
+func TestProxyMetricsDuplicateRegistration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	m1 := newProxyMetrics(reg)
+	m2 := newProxyMetrics(reg) // previously panicked: "duplicate metrics collector registration attempted"
+
+	m1.connectionOpened("up")
+	m2.connectionOpened("up")
+
+	// Both handlers write to the same registered collector.
+	if got := testutil.ToFloat64(m1.connectionsTotal.WithLabelValues("up")); got != 2 {
+		t.Errorf("connections_total = %v, want 2 (collectors must be shared)", got)
+	}
+	if m1.connectionsTotal != m2.connectionsTotal {
+		t.Error("expected the second proxy handler to reuse the existing collector")
+	}
+}
+
 func TestActiveHealthCheckUpdatesHealthMetricDown(t *testing.T) {
 	addr, err := caddy.ParseNetworkAddress("127.0.0.1:1") // nothing listening
 	if err != nil {


### PR DESCRIPTION
Fixes #445 — a regression I introduced in #431.

## The bug

Several `proxy` handlers in one config all obtain the same instance metrics registry from `ctx.GetMetricsRegistry()`. `newProxyMetrics` used `promauto.With(reg).New…Vec(…)`, which calls `MustRegister`, so the **second** proxy handler to provision panics:

```
panic: duplicate metrics collector registration attempted
  …/prometheus/promauto/auto.go:276
  l4proxy.newProxyMetrics(…) modules/l4proxy/metrics.go:35
  l4proxy.(*Handler).Provision(…) modules/l4proxy/proxy.go:83
```

Any config with more than one `proxy` handler crashes at startup.

## The fix

Register each collector with `reg.Register(…)` and, on `AlreadyRegisteredError`, reuse the already-registered collector instead of panicking. All proxy handlers then share one set of metrics (which is what you want — the counters are labeled by upstream, not by handler).

Added `TestProxyMetricsDuplicateRegistration`, which provisions the metrics twice against one registry: it panicked before, and now passes and asserts the collectors are shared. `metrics.go` stays at 100% coverage.

Sorry for the breakage. The new `metrics` handler in #444 has the same shape and I'm applying the same fix there.