### PR TITLE
regexp: Introduce hex option to match non-UTF8 bytes

### DIFF
--- a/docs/matchers/regexp.md
+++ b/docs/matchers/regexp.md
@@ -17,12 +17,21 @@ The matcher also has `count` field that sets the number of bytes read from the b
 to match against. By default, it equals `4`. It shouldn't exceed `16 KiB` (`MaxMatchingBytes` constant value) which is
 the amount of bytes that are at most prefetched during matching.
 
+The matcher additionally has a boolean `hex` field. When it is enabled, the bytes read are first converted to their
+uppercase hexadecimal representation (e.g. `9E79BC40`), and the pattern is matched against that string rather than
+against the raw bytes. This makes it possible to match byte sequences that aren't valid UTF-8 (see
+[golang/go#48749](https://github.com/golang/go/issues/48749)), at the cost of the extra conversion performed on each
+matcher test. When you don't deal with non-UTF-8 sequences, leave `hex` disabled: standard matching is enough and
+works faster.
+
 ### Caddyfile
 
 The matcher supports the following syntax:
 ```caddyfile
-regexp <pattern> [<count>]
+regexp <pattern> [<count>] [hex]
 ```
+
+The optional `count` and `hex` arguments may appear in any order.
 
 An example config of the Layer 4 app that proxies connections based on regular expressions applied
 to their first packets:
@@ -57,6 +66,16 @@ to their first packets:
             @r3 regexp ^(b|c|r)at(.*)\x00\x00$ 10
             route @r3 {
                 proxy r3.machine.local:10001
+            }
+            
+            # proxy to r4.machine.local:10001
+            # any traffic on TCP port 12345
+            # if the first 4 bytes Caddy receives
+            # are `9E ?? BC 4?` (matched on their hex
+            # representation, so non-UTF-8 bytes work)
+            @r4 regexp ^9E..BC4.$ 4 hex
+            route @r4 {
+                proxy r4.machine.local:10001
             }
             
             # otherwise echo anything received on TCP port 12345
@@ -140,6 +159,29 @@ JSON equivalent to the caddyfile config provided above:
                                         {
                                             "dial": [
                                                 "r3.machine.local:10001"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "match": [
+                                {
+                                    "regexp": {
+                                        "count": 4,
+                                        "hex": true,
+                                        "pattern": "^9E..BC4.$"
+                                    }
+                                }
+                            ],
+                            "handle": [
+                                {
+                                    "handler": "proxy",
+                                    "upstreams": [
+                                        {
+                                            "dial": [
+                                                "r4.machine.local:10001"
                                             ]
                                         }
                                     ]

--- a/modules/l4regexp/matcher.go
+++ b/modules/l4regexp/matcher.go
@@ -15,9 +15,11 @@
 package l4regexp
 
 import (
+	"encoding/hex"
 	"io"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -32,6 +34,7 @@ func init() {
 // MatchRegexp is able to match any connections with regular expressions.
 type MatchRegexp struct {
 	Count   uint16 `json:"count,omitempty"`
+	Hex     bool   `json:"hex,omitempty"`
 	Pattern string `json:"pattern,omitempty"`
 
 	compiled *regexp.Regexp
@@ -54,6 +57,14 @@ func (m *MatchRegexp) Match(cx *layer4.Connection) (bool, error) {
 		return false, err
 	}
 
+	// When the hex option is enabled, match the regular expression against an
+	// uppercase hexadecimal representation of the bytes. This makes it possible
+	// to match byte sequences that aren't valid UTF-8, at the cost of the extra
+	// conversion. Otherwise, match the raw bytes as-is.
+	if m.Hex {
+		return m.compiled.MatchString(strings.ToUpper(hex.EncodeToString(buf))), nil
+	}
+
 	// Match these bytes against the regular expression
 	return m.compiled.Match(buf), nil
 }
@@ -73,22 +84,38 @@ func (m *MatchRegexp) Provision(_ caddy.Context) (err error) {
 
 // UnmarshalCaddyfile sets up the MatchRegexp from Caddyfile tokens. Syntax:
 //
-//	regexp <pattern> [<count>]
+//	regexp <pattern> [<count>] [hex]
+//
+// The optional count and hex arguments may appear in any order. When hex is
+// present, the pattern is matched against an uppercase hexadecimal
+// representation of the bytes instead of the raw bytes.
 func (m *MatchRegexp) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	_, wrapper := d.Next(), d.Val() // consume wrapper name
 
-	// One or two same-line argument must be provided
-	if d.CountRemainingArgs() == 0 || d.CountRemainingArgs() > 2 {
+	// One to three same-line arguments must be provided
+	if d.CountRemainingArgs() == 0 || d.CountRemainingArgs() > 3 {
 		return d.ArgErr()
 	}
 
 	_, m.Pattern = d.NextArg(), d.Val()
-	if d.NextArg() {
-		val, err := strconv.ParseUint(d.Val(), 10, 16)
+	hasCount := false
+	for d.NextArg() {
+		val := d.Val()
+		if val == hexOption {
+			if m.Hex {
+				return d.Errf("duplicate %s %s option", wrapper, hexOption)
+			}
+			m.Hex = true
+			continue
+		}
+		if hasCount {
+			return d.Errf("malformed %s option: unexpected argument %q", wrapper, val)
+		}
+		count, err := strconv.ParseUint(val, 10, 16)
 		if err != nil {
 			return d.Errf("parsing %s count: %v", wrapper, err)
 		}
-		m.Count = uint16(val)
+		m.Count, hasCount = uint16(count), true
 	}
 
 	// No blocks are supported
@@ -107,5 +134,7 @@ var (
 )
 
 const (
+	hexOption = "hex" // enables matching against a hexadecimal representation of the bytes
+
 	minCount uint16 = 4 // by default, read this many bytes to match against
 )

--- a/modules/l4regexp/matcher_test.go
+++ b/modules/l4regexp/matcher_test.go
@@ -52,6 +52,11 @@ func Test_MatchRegexp_Match(t *testing.T) {
 		{matcher: &MatchRegexp{Pattern: "^\\d+$"}, data: packet0123, shouldMatch: true},
 		{matcher: &MatchRegexp{Pattern: "^\\d+$", Count: 0}, data: packet0123, shouldMatch: true},
 		{matcher: &MatchRegexp{Pattern: "^\x30\x31\x32(\x33|\x34)$", Count: 0}, data: packet0123, shouldMatch: true},
+		{matcher: &MatchRegexp{Pattern: "^30313233$", Hex: true}, data: packet0123, shouldMatch: true},
+		{matcher: &MatchRegexp{Pattern: "^303132(33|34)$", Hex: true}, data: packet0123, shouldMatch: true},
+		{matcher: &MatchRegexp{Pattern: "^30313234$", Hex: true}, data: packet0123, shouldMatch: false},
+		{matcher: &MatchRegexp{Pattern: "^9E79BC40$", Hex: true, Count: 4}, data: packetNonUTF8, shouldMatch: true},
+		{matcher: &MatchRegexp{Pattern: "^9E7\\dBC4\\d$", Hex: true, Count: 4}, data: packetNonUTF8, shouldMatch: true},
 	}
 
 	ctx, cancel := caddy.NewContext(caddy.Context{Context: context.Background()})
@@ -90,3 +95,5 @@ func Test_MatchRegexp_Match(t *testing.T) {
 }
 
 var packet0123 = []byte{0x30, 0x31, 0x32, 0x33}
+
+var packetNonUTF8 = []byte{0x9E, 0x79, 0xBC, 0x40}


### PR DESCRIPTION
This PR introduces `hex` option to match non-UTF8 byte sequences with `regexp` matcher following the discussion [here](https://github.com/mholt/caddy-l4/issues/419).

Caddyfile example:
```caddyfile
# the following block proxies connections to backend:80
# if the first 4 bytes Caddy receives are 9E 7? BC 4?
@non-utf8 regexp ^9E7\dBC4\d$ 4 hex
route @non-utf8 {
    proxy backend:80
}
```

The code was drafted by Clause Opus 4.8.