### PR TITLE
proxy_protocol: Support PROXY headers on every UDP datagram

### DIFF
--- a/layer4/connection.go
+++ b/layer4/connection.go
@@ -190,6 +190,27 @@ func (cx *Connection) Wrap(conn net.Conn) *Connection {
 	}
 }
 
+// WrapWithEmptyBuffer is like Wrap, but the returned Connection starts with an
+// empty prefetch buffer instead of inheriting cx's. Use it when conn already
+// reads through cx — and therefore already delivers any bytes cx previously
+// prefetched — so that those bytes are not also served directly from the
+// returned Connection's buffer, bypassing conn. This is required by the packet
+// (e.g. UDP) PROXY protocol reader, which must strip a header from every
+// datagram: letting the prefetched datagrams leak through the buffer unwrapped
+// would forward them with their PROXY headers still attached.
+func (cx *Connection) WrapWithEmptyBuffer(conn net.Conn) *Connection {
+	wrapped := cx.Wrap(conn)
+	wrapped.buf, wrapped.offset = nil, 0
+	return wrapped
+}
+
+// IsPacketConn reports whether the underlying connection is a packet
+// (datagram) connection, such as UDP. Datagram connections preserve message
+// boundaries, which some handlers must account for.
+func (cx *Connection) IsPacketConn() bool {
+	return cx.isPacketConn
+}
+
 // prefetch tries to read all bytes that a client initially sent us without blocking.
 func (cx *Connection) prefetch() (err error) {
 	var n int

--- a/modules/l4proxyprotocol/handler.go
+++ b/modules/l4proxyprotocol/handler.go
@@ -200,6 +200,13 @@ func (h *Handler) newConn(cx *layer4.Connection) *proxyproto.Conn {
 
 // Handle handles the connections.
 func (h *Handler) Handle(cx *layer4.Connection, next layer4.Handler) error {
+	// Packet (e.g. UDP) connections carry a PROXY header on every datagram, so
+	// they need per-datagram handling rather than go-proxyproto's stream reader,
+	// which only strips a single header for the whole connection.
+	if cx.IsPacketConn() {
+		return h.handlePacket(cx, next)
+	}
+
 	conn := h.newConn(cx)
 	if conn == nil {
 		h.logger.Debug("untrusted party not allowed",
@@ -236,6 +243,51 @@ func (h *Handler) Handle(cx *layer4.Connection, next layer4.Handler) error {
 	cx.SetVar(connReplKey, conn)
 
 	return next.Handle(cx.Wrap(conn))
+}
+
+// handlePacket handles packet (e.g. UDP) connections, where a PROXY header
+// precedes every datagram rather than just the first bytes of a stream.
+func (h *Handler) handlePacket(cx *layer4.Connection, next layer4.Handler) error {
+	// Determine the policy from the immediate peer, mirroring the stream path.
+	policy, err := h.policy(proxyproto.ConnPolicyOptions{Upstream: cx.RemoteAddr()})
+	if err != nil {
+		h.logger.Debug("policy check failed", zap.Error(err))
+		return next.Handle(cx)
+	}
+	// REJECT and SKIP both mean "do not consume PROXY headers here"; pass the
+	// datagrams through untouched, just as the stream path does.
+	if policy == proxyproto.REJECT {
+		h.logger.Debug("untrusted party not allowed",
+			zap.String("remote", cx.RemoteAddr().String()),
+			zap.Strings("allow", h.Allow),
+		)
+		return next.Handle(cx)
+	}
+	if policy == proxyproto.SKIP {
+		return next.Handle(cx)
+	}
+
+	conn := newPacketConn(cx, policy == proxyproto.REQUIRE)
+
+	// Read the first datagram so that the PROXY header addresses are available
+	// to downstream handlers (e.g. for logging or re-emitting the header).
+	if err := conn.prime(time.Duration(h.Timeout)); err != nil {
+		h.logger.Debug("reading PROXY header failed", zap.Error(err))
+		return err
+	}
+
+	h.logger.Debug("connection established",
+		zap.String("remote", conn.RemoteAddr().String()),
+		zap.String("local", conn.LocalAddr().String()),
+	)
+
+	// Set conn as a custom variable on cx.
+	cx.SetVar(connReplKey, conn)
+
+	// conn reads through cx, so hand next a Connection with an empty prefetch
+	// buffer; otherwise the prefetched datagrams would be served raw (with their
+	// PROXY headers still attached), bypassing conn.
+	return next.Handle(cx.WrapWithEmptyBuffer(conn))
 }
 
 // UnmarshalCaddyfile sets up the Handler from Caddyfile tokens. Syntax:

--- a/modules/l4proxyprotocol/packet.go
+++ b/modules/l4proxyprotocol/packet.go
@@ -1,0 +1,193 @@
+// Copyright 2020 Matthew Holt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4proxyprotocol
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"time"
+
+	"github.com/pires/go-proxyproto"
+)
+
+// maxDatagramSize bounds a single datagram read from a packet connection. It
+// matches the buffer size layer4 uses for reading UDP datagrams (sized for
+// jumbo frames), so a whole datagram is always returned by a single Read.
+const maxDatagramSize = 9000
+
+// ErrPacketHeaderRequired is returned while reading from a packet connection
+// when a PROXY header is required by policy but a datagram arrives without one.
+var ErrPacketHeaderRequired = errors.New("PROXY header required but not received")
+
+// packetConn wraps a packet (e.g. UDP) connection whose datagrams are each
+// prefixed with a PROXY protocol header, stripping the header from every
+// datagram it reads.
+//
+// This differs fundamentally from a stream connection: on a stream a single
+// PROXY header precedes the whole byte stream and is consumed once (which is
+// what github.com/pires/go-proxyproto does). caddy-l4's packet PROXY protocol
+// writer (see modules/l4proxy) instead prepends a header to every datagram, so
+// the reader has to strip one header per datagram rather than only once.
+type packetConn struct {
+	net.Conn
+
+	// requireHeader rejects datagrams that arrive without a PROXY header.
+	requireHeader bool
+
+	// readBuf is a reusable buffer for reading a whole datagram.
+	readBuf []byte
+	// payload holds the not-yet-consumed payload of the current datagram.
+	payload []byte
+	// pendingErr is a read error observed together with payload data; it is
+	// surfaced only after the buffered payload has been fully consumed.
+	pendingErr error
+
+	// srcAddr and dstAddr are taken from the first PROXY header seen and are
+	// reported by RemoteAddr and LocalAddr respectively, mirroring the stream
+	// handler's behavior.
+	srcAddr, dstAddr net.Addr
+}
+
+// newPacketConn wraps conn, which must deliver exactly one datagram per Read
+// (as a layer4.Connection backed by a packet conn does).
+func newPacketConn(conn net.Conn, requireHeader bool) *packetConn {
+	return &packetConn{
+		Conn:          conn,
+		requireHeader: requireHeader,
+		readBuf:       make([]byte, maxDatagramSize),
+	}
+}
+
+// prime reads the first datagram so that RemoteAddr and LocalAddr reflect the
+// PROXY header before any payload is forwarded downstream. The stripped payload
+// (if any) is buffered for the next Read. A non-zero timeout bounds the wait;
+// if it elapses before a datagram arrives, priming is a no-op unless a header
+// is required (nothing has been consumed, so later datagrams are still read).
+func (c *packetConn) prime(timeout time.Duration) error {
+	if timeout > 0 {
+		_ = c.Conn.SetReadDeadline(time.Now().Add(timeout))
+		defer func() { _ = c.Conn.SetReadDeadline(time.Time{}) }()
+	}
+	payload, err := c.readDatagram()
+	if len(payload) > 0 {
+		c.payload = append(c.payload[:0], payload...)
+	}
+	if err != nil {
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() && !c.requireHeader {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// readDatagram reads a single datagram and returns its payload with the PROXY
+// header (if any) stripped off. The returned slice is safe to retain: it does
+// not alias the reusable read buffer.
+func (c *packetConn) readDatagram() ([]byte, error) {
+	n, err := c.Conn.Read(c.readBuf)
+	if n == 0 {
+		return nil, err
+	}
+	payload, herr := c.stripHeader(c.readBuf[:n])
+	if herr != nil {
+		return nil, herr
+	}
+	out := make([]byte, len(payload))
+	copy(out, payload)
+	return out, err
+}
+
+// stripHeader parses and removes a PROXY protocol header from the front of a
+// datagram, returning the remaining payload. If no header is present, the
+// datagram is returned unchanged (or rejected when a header is required).
+func (c *packetConn) stripHeader(datagram []byte) ([]byte, error) {
+	br := bufio.NewReader(bytes.NewReader(datagram))
+	header, err := proxyproto.Read(br)
+	if err != nil {
+		if errors.Is(err, proxyproto.ErrNoProxyProtocol) {
+			if c.requireHeader {
+				return nil, ErrPacketHeaderRequired
+			}
+			return datagram, nil
+		}
+		return nil, err
+	}
+	// Record the addresses from the first PROXY (not LOCAL) header so that
+	// RemoteAddr/LocalAddr stay stable across the connection's datagrams.
+	if header.Command == proxyproto.PROXY && c.srcAddr == nil {
+		c.srcAddr, c.dstAddr = header.SourceAddr, header.DestinationAddr
+	}
+	// Everything after the header is the datagram's payload.
+	remaining, _ := io.ReadAll(br)
+	return remaining, nil
+}
+
+// Read returns the header-stripped payload of the packet stream. Each datagram
+// is unwrapped independently.
+func (c *packetConn) Read(b []byte) (int, error) {
+	// Serve any leftover payload from the current datagram first.
+	if len(c.payload) > 0 {
+		n := copy(b, c.payload)
+		c.payload = c.payload[n:]
+		return n, nil
+	}
+	if c.pendingErr != nil {
+		err := c.pendingErr
+		c.pendingErr = nil
+		return 0, err
+	}
+	for {
+		payload, err := c.readDatagram()
+		if len(payload) > 0 {
+			n := copy(b, payload)
+			if n < len(payload) {
+				c.payload = append(c.payload[:0], payload[n:]...)
+			}
+			// Surface any read error only after the payload is drained.
+			c.pendingErr = err
+			return n, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+		// Header-only datagram (e.g. no payload); move on to the next one.
+	}
+}
+
+// RemoteAddr returns the source address from the PROXY header if one was seen,
+// otherwise the underlying connection's remote address.
+func (c *packetConn) RemoteAddr() net.Addr {
+	if c.srcAddr != nil {
+		return c.srcAddr
+	}
+	return c.Conn.RemoteAddr()
+}
+
+// LocalAddr returns the destination address from the PROXY header if one was
+// seen, otherwise the underlying connection's local address.
+func (c *packetConn) LocalAddr() net.Addr {
+	if c.dstAddr != nil {
+		return c.dstAddr
+	}
+	return c.Conn.LocalAddr()
+}
+
+// Interface guard
+var _ net.Conn = (*packetConn)(nil)

--- a/modules/l4proxyprotocol/packet_test.go
+++ b/modules/l4proxyprotocol/packet_test.go
@@ -1,0 +1,169 @@
+package l4proxyprotocol
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pires/go-proxyproto"
+)
+
+// fakeDatagramConn is a net.Conn that hands out one preloaded datagram per
+// Read, emulating how a layer4.Connection backed by a packet (UDP) conn
+// delivers data on message boundaries.
+type fakeDatagramConn struct {
+	datagrams     [][]byte
+	idx           int
+	local, remote net.Addr
+}
+
+func (f *fakeDatagramConn) Read(b []byte) (int, error) {
+	if f.idx >= len(f.datagrams) {
+		return 0, io.EOF
+	}
+	n := copy(b, f.datagrams[f.idx])
+	f.idx++
+	return n, nil
+}
+
+func (f *fakeDatagramConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (f *fakeDatagramConn) Close() error                     { return nil }
+func (f *fakeDatagramConn) LocalAddr() net.Addr              { return f.local }
+func (f *fakeDatagramConn) RemoteAddr() net.Addr             { return f.remote }
+func (f *fakeDatagramConn) SetDeadline(time.Time) error      { return nil }
+func (f *fakeDatagramConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeDatagramConn) SetWriteDeadline(time.Time) error { return nil }
+
+// buildDatagram mirrors l4proxy's packetProxyProtocolConn.Write: a PROXY v2
+// header (built from src/dst) immediately followed by the payload, all in a
+// single datagram.
+func buildDatagram(src, dst *net.UDPAddr, payload []byte) []byte {
+	h := proxyproto.HeaderProxyFromAddrs(2, src, dst)
+	buf := new(bytes.Buffer)
+	_, _ = h.WriteTo(buf)
+	buf.Write(payload)
+	return buf.Bytes()
+}
+
+// TestPacketConnStripsHeaderFromEveryDatagram is the core regression test for
+// issue #451: caddy-l4's packet PROXY protocol writer prepends a header to
+// every datagram, so the reader must strip a header from every datagram — not
+// just the first, as go-proxyproto's stream reader does.
+func TestPacketConnStripsHeaderFromEveryDatagram(t *testing.T) {
+	src := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 12345}
+	dst := &net.UDPAddr{IP: net.IPv4(5, 6, 7, 8), Port: 443}
+
+	payloads := [][]byte{[]byte("first"), []byte("second"), []byte("third")}
+	datagrams := make([][]byte, 0, len(payloads))
+	for _, pl := range payloads {
+		datagrams = append(datagrams, buildDatagram(src, dst, pl))
+	}
+
+	conn := newPacketConn(&fakeDatagramConn{datagrams: datagrams, local: dst, remote: src}, false)
+
+	// Priming reads the first datagram so addresses reflect the PROXY header.
+	if err := conn.prime(0); err != nil {
+		t.Fatalf("prime failed: %v", err)
+	}
+	assertString(t, "1.2.3.4:12345", conn.RemoteAddr().String())
+	assertString(t, "5.6.7.8:443", conn.LocalAddr().String())
+
+	// Every datagram's payload must come back with its header stripped.
+	for i, want := range payloads {
+		b := make([]byte, maxDatagramSize)
+		n, err := conn.Read(b)
+		if err != nil {
+			t.Fatalf("datagram %d: Read error: %v", i, err)
+		}
+		if got := string(b[:n]); got != string(want) {
+			t.Fatalf("datagram %d: got %q, want %q (PROXY header not stripped?)", i, got, want)
+		}
+	}
+
+	// After the last datagram, the underlying EOF should surface.
+	if _, err := conn.Read(make([]byte, maxDatagramSize)); err != io.EOF {
+		t.Fatalf("expected io.EOF after last datagram, got %v", err)
+	}
+}
+
+// TestPacketConnPassesThroughWhenHeaderNotRequired verifies that datagrams
+// without a PROXY header are forwarded unchanged when the policy does not
+// require one.
+func TestPacketConnPassesThroughWhenHeaderNotRequired(t *testing.T) {
+	datagrams := [][]byte{[]byte("no-header-here"), []byte("still-plain")}
+	conn := newPacketConn(&fakeDatagramConn{
+		datagrams: datagrams,
+		local:     &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5000},
+		remote:    &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6000},
+	}, false)
+
+	if err := conn.prime(0); err != nil {
+		t.Fatalf("prime failed: %v", err)
+	}
+	// No PROXY header seen, so addresses fall back to the underlying conn.
+	assertString(t, "127.0.0.1:6000", conn.RemoteAddr().String())
+
+	for i, want := range datagrams {
+		b := make([]byte, maxDatagramSize)
+		n, err := conn.Read(b)
+		if err != nil {
+			t.Fatalf("datagram %d: Read error: %v", i, err)
+		}
+		if got := string(b[:n]); got != string(want) {
+			t.Fatalf("datagram %d: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestPacketConnRequiredHeaderMissing verifies that a datagram lacking a
+// required PROXY header is rejected.
+func TestPacketConnRequiredHeaderMissing(t *testing.T) {
+	conn := newPacketConn(&fakeDatagramConn{
+		datagrams: [][]byte{[]byte("plain datagram")},
+		local:     &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 5000},
+		remote:    &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6000},
+	}, true)
+
+	err := conn.prime(0)
+	if err != ErrPacketHeaderRequired {
+		t.Fatalf("expected ErrPacketHeaderRequired, got %v", err)
+	}
+}
+
+// TestPacketConnPayloadLargerThanReadBuffer verifies that a datagram payload
+// larger than the caller's buffer is delivered across multiple Reads without
+// loss or corruption.
+func TestPacketConnPayloadLargerThanReadBuffer(t *testing.T) {
+	src := &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 1}
+	dst := &net.UDPAddr{IP: net.IPv4(5, 6, 7, 8), Port: 2}
+
+	payload := bytes.Repeat([]byte("A"), 1000)
+	conn := newPacketConn(&fakeDatagramConn{
+		datagrams: [][]byte{buildDatagram(src, dst, payload)},
+		local:     dst,
+		remote:    src,
+	}, false)
+
+	if err := conn.prime(0); err != nil {
+		t.Fatalf("prime failed: %v", err)
+	}
+
+	// Read in small chunks to force the leftover-payload path.
+	var got []byte
+	for {
+		b := make([]byte, 64)
+		n, err := conn.Read(b)
+		got = append(got, b[:n]...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Read error: %v", err)
+		}
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("reassembled payload mismatch: got %d bytes, want %d", len(got), len(payload))
+	}
+}


### PR DESCRIPTION
## AI Disclosure

This PR was drafted by Claude Opus 4.8 following the discussion in #451.

My brief curl-based tests show it fixes this issue. But I don't use the proxy protocol much, so I can't test it extensively.

## Description

The proxy_protocol handler delegated to go-proxyproto, whose Conn strips exactly one PROXY header per connection (guarded by a sync.Once). That matches a byte stream, but caddy-l4's own packet writer prepends a header to every datagram, so over UDP only the first datagram was unwrapped and every subsequent datagram's header leaked through as payload.

Add a per-datagram reader for packet connections that strips a PROXY header off each datagram, and route UDP conns to it while leaving the stream (TCP/Unix) path on go-proxyproto unchanged.

- layer4: add Connection.IsPacketConn() and WrapWithEmptyBuffer(). The latter is needed because the packet reader reads through cx, so the wrapped Connection must not also serve the already-prefetched datagrams raw from the shared buffer.
- l4proxyprotocol: add packetConn (packet.go) which parses and strips a header per datagram, buffers leftover payload across Reads, exposes the first header's addresses via RemoteAddr/LocalAddr, and honors the require/passthrough policy; branch Handle to it for packet conns.
- Add tests covering per-datagram stripping, passthrough when no header is required, rejection when required but missing, and payloads larger than the read buffer.